### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+#
+# Note the required access permissions for users and teams to the repository.
+
+# The runtime maintainers are the default owners of all files
+# in this repository, unless a later match takes precedence.
+* @intel/fpga-runtime-for-opencl-maintain
+
+# Profiler
+acl_profiler* @intel/fpga-runtime-for-opencl-maintain @smffraser


### PR DESCRIPTION
I tested a variation of this file in a personal repository under my account by [inspecting files for the ownership icon](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners) at the top left, though this only worked with users since teams cannot be invited as collaborators to a **personal** repository and hence do not work in the `CODEOWNERS` file.