### PR TITLE
Fix actions/checkout@v2 on Ubuntu 18.04

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -60,6 +60,8 @@ jobs:
     env:
       image: ghcr.io/${{ github.repository }}/${{ matrix.container }}
 
+    continue-on-error: true
+
     steps:
       - name: checkout code
         uses: actions/checkout@v2

--- a/container/ubuntu-18.04-dev/Dockerfile
+++ b/container/ubuntu-18.04-dev/Dockerfile
@@ -11,7 +11,20 @@ WORKDIR /work
 # to extend the `paths` on which the workflow runs.
 COPY scripts/. ./
 
+# Ubuntu 18.04 ships with Git 2.17.1 [1] while actions/checkout@v2
+# requires Git 2.18 or newer [2, 3]. Install the latest stable release
+# from the PPA [4] maintained by Anders Kaseorg <andersk@mit.edu> [5],
+# who has previously co-maintained the official Debian git package [6].
+#
+# [1] https://packages.ubuntu.com/bionic/git
+# [2] https://github.com/rocker-org/rocker-versioned2/issues/52
+# [3] https://github.com/actions/checkout/issues/238
+# [4] https://launchpad.net/~git-core/+archive/ubuntu/ppa
+# [5] https://launchpad.net/~andersk
+# [6] https://tracker.debian.org/pkg/git
 RUN apt-get -y update \
+  && apt-get -y install software-properties-common \
+  && add-apt-repository ppa:git-core/ppa \
   && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade \
   build-essential \
   ca-certificates \


### PR DESCRIPTION
This resolves a build workflow failure on Ubuntu 18.04, which requires
an actual git checkout to verify the manifests of installed components.
    
```
The repository will be downloaded using the GitHub REST API
To create a local Git repository instead, add Git 2.18 or higher to the PATH
```