### PR TITLE
Do not delete aocl installer after installation

### DIFF
--- a/scripts/install_aocl.sh
+++ b/scripts/install_aocl.sh
@@ -19,4 +19,3 @@ installer_url="https://download.altera.com/akdlm/software/acdsinst/$major.$minor
 curl -L -o "$installer" "$installer_url"
 chmod +x "$installer"
 ./"$installer" --mode unattended --installdir "$installdir" --accept_eula 1
-rm "$installer"


### PR DESCRIPTION
In the containers builds where this script is used, the working directory
is removed after installation anyway. When this script is used locally,
however, keeping the installer around may be useful for debugging.