### PR TITLE
Permit workflows to read container images

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -5,6 +5,15 @@
 
 name: build on Linux
 
+# https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
+permissions:
+  # Grant read permissions to repository in case it is not a forked public
+  # repository, but a private repository that was created manually.
+  contents: read
+
+  # Grant read permissions to private container images.
+  packages: read
+
 on:
   push:
     paths:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,6 +5,15 @@
 
 name: run clang-format
 
+# https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
+permissions:
+  # Grant read permissions to repository in case it is not a forked public
+  # repository, but a private repository that was created manually.
+  contents: read
+
+  # Grant read permissions to private container images.
+  packages: read
+
 on:
   push:
     paths:


### PR DESCRIPTION
The container images have private visibility since they are used
in the CI workflows only and not intended for public distribution.