### PR TITLE
Limit container image push to current tag

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -94,4 +94,6 @@ jobs:
 
       - name: push image to registry
         if: github.event_name == 'push'
-        run: docker image push --all-tags "$image"
+        run: docker image push "$image:$tag"
+        env:
+          tag: ${{ steps.tag.outputs.tag }}


### PR DESCRIPTION
When using a self-hosted actions runner, `docker image push --all-tags`
also pushes all image tags built in previous container workflow runs.