### PR TITLE
Add BDBA scanning workflow

### DIFF
--- a/.github/workflows/bdba.yml
+++ b/.github/workflows/bdba.yml
@@ -1,0 +1,96 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: BDBA scan
+
+# https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
+permissions:
+  # Grant read permissions to repository in case it is not a forked public
+  # repository, but a private repository that was created manually.
+  contents: read
+
+  # Grant read permissions to private container images.
+  packages: read
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**'
+      - '!**.md'
+      - '!**/.clang-format'
+      - '!**/COPYING'
+      - '!**/LICENSE'
+      - '!.github/**'
+      - '.github/workflows/bdba.yml'
+      - '!.gitignore'
+      - '!cmake/manifests/**'
+      - '!container/**'
+      - '!docs/**'
+      - '!scripts/**'
+
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - container
+
+    container:
+      image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-20.04-dev:main
+
+    # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
+    environment: bdba
+
+    steps:
+      - name: change ownership of workspace to current user
+        run: sudo chown -R build:build .
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: create build directory
+        run: mkdir build
+
+      - name: create build files
+        run: |
+          cd build
+          cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_LIBDIR=lib
+
+      - name: build runtime without unit tests
+        run: |
+          cd build
+          ninja -v -k0 acl
+
+      - name: create binary package
+        run: |
+          cd build
+          cpack -G TGZ
+
+      - name: list binary package
+        run: tar tvfz build/fpga-runtime-for-opencl-*-Linux.tar.gz
+
+      - name: submit binary package
+        run: |
+          printf 'Authorization: Bearer %s\nGroup: %s\n' "$BDBA_KEY" "$BDBA_GROUP" | curl \
+            --fail \
+            --silent \
+            --header @- \
+            --output upload.json \
+            --upload-file build/fpga-runtime-for-opencl-*-Linux.tar.gz \
+            "$BDBA_URL/api/upload/fpga-runtime-for-opencl-$GITHUB_SHA.tar.gz"
+        env:
+          BDBA_GROUP: ${{ secrets.BDBA_GROUP }}
+          BDBA_KEY: ${{ secrets.BDBA_KEY }}
+          BDBA_URL: ${{ secrets.BDBA_URL }}
+
+      - name: print upload id
+        run: jq --exit-status .results.product_id upload.json
+
+      - name: revert ownership of workspace to root
+        run: sudo chown -R root:root .
+        if: always()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 cmake_minimum_required(VERSION 3.10)
 
-project(fpga-runtime C CXX)
+project(fpga-runtime-for-opencl C CXX)
 
 # https://gitlab.kitware.com/cmake/community/-/wikis/doc/cpack/Packaging-With-CPack
 # https://cmake.org/cmake/help/v3.10/module/CPack.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,16 @@ cmake_minimum_required(VERSION 3.10)
 
 project(fpga-runtime C CXX)
 
+# https://gitlab.kitware.com/cmake/community/-/wikis/doc/cpack/Packaging-With-CPack
+# https://cmake.org/cmake/help/v3.10/module/CPack.html
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Intel(R) FPGA Runtime for OpenCL(TM) Software Technology")
+set(CPACK_PACKAGE_VENDOR "Intel Corporation")
+set(CPACK_PACKAGE_VERSION_MAJOR "2022")
+set(CPACK_PACKAGE_VERSION_MINOR "1")
+set(CPACK_PACKAGE_VERSION_PATCH "0")
+set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
+set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+
 # Enforce keeping the source directory clean by building in a separate
 # directory. This avoids unnecessary corner cases, e.g., copying files
 # from source to binary directory with identical relative paths.
@@ -110,6 +120,7 @@ if(ACL_WITH_ASAN)
   endforeach()
 endif()
 
+include(CPack)
 include(CTest)
 
 # Get CMAKE_INSTALL_<dir> variables to enable custom library, binary, and include paths


### PR DESCRIPTION
See [intel/fpga-runtime-for-opencl/runs/4231767557](https://github.com/intel/fpga-runtime-for-opencl/runs/4231767557?check_suite_focus=true) for a partial test run up before submission, which fails as expected since pull requests from forked repositories do not have access to secrets. This workflow will only run on the `main` branch.