### PR TITLE
Switch BDBA scanning workflow to dedicated container image

### DIFF
--- a/.github/workflows/bdba.yml
+++ b/.github/workflows/bdba.yml
@@ -41,7 +41,7 @@ jobs:
       - container
 
     container:
-      image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-20.04-dev:main
+      image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-20.04-bdba:main
 
     # https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment
     environment: bdba

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -80,16 +80,17 @@ jobs:
         env:
           ref: ${{ github.ref }}
 
-      - name: login to registry
-        run: echo "$token" | docker login ghcr.io -u "$user" --password-stdin
-        env:
-          user: ${{ github.repository_owner }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: build image
         run: docker build -t "$image:$tag" -f container/${{ matrix.container }}/Dockerfile .
         env:
           tag: ${{ steps.tag.outputs.tag }}
+
+      - name: login to registry
+        if: github.event_name == 'push'
+        run: echo "$token" | docker login ghcr.io -u "$user" --password-stdin
+        env:
+          user: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: push image to registry
         if: github.event_name == 'push'

--- a/container/centos-8-dev/Dockerfile
+++ b/container/centos-8-dev/Dockerfile
@@ -3,11 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM ghcr.io/intel/fpga-runtime-for-opencl/certificates AS certificates
-
 FROM centos:8
-
-COPY --from=certificates /*.crt /etc/pki/ca-trust/source/anchors/
 
 WORKDIR /work
 
@@ -40,7 +36,6 @@ RUN sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo \
   which \
   zlib-devel \
   && yum -y clean all \
-  && update-ca-trust \
   && ./install_aocl.sh /opt/aocl \
   && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \

--- a/container/debian-11-arm-dev/Dockerfile
+++ b/container/debian-11-arm-dev/Dockerfile
@@ -3,11 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM ghcr.io/intel/fpga-runtime-for-opencl/certificates AS certificates
-
 FROM debian:11
-
-COPY --from=certificates /*.crt /usr/local/share/ca-certificates/
 
 WORKDIR /work
 
@@ -36,7 +32,6 @@ RUN dpkg --add-architecture armhf \
   libelf-dev:armhf \
   zlib1g-dev:armhf \
   && apt-get -y clean \
-  && update-ca-certificates \
   && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
   && rm -rf "$PWD"

--- a/container/opensuse-leap-15-dev/Dockerfile
+++ b/container/opensuse-leap-15-dev/Dockerfile
@@ -3,11 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM ghcr.io/intel/fpga-runtime-for-opencl/certificates AS certificates
-
 FROM opensuse/leap:15
-
-COPY --from=certificates /*.crt /etc/pki/trust/anchors/
 
 WORKDIR /work
 
@@ -35,7 +31,6 @@ RUN zypper -n update \
   which \
   zlib-devel \
   && zypper -n clean \
-  && update-ca-certificates \
   && ./install_aocl.sh /opt/aocl \
   && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \

--- a/container/ubuntu-18.04-dev/Dockerfile
+++ b/container/ubuntu-18.04-dev/Dockerfile
@@ -3,11 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM ghcr.io/intel/fpga-runtime-for-opencl/certificates AS certificates
-
 FROM ubuntu:18.04
-
-COPY --from=certificates /*.crt /usr/local/share/ca-certificates/
 
 WORKDIR /work
 
@@ -44,7 +40,6 @@ RUN apt-get -y update \
   sudo \
   zlib1g-dev \
   && apt-get -y clean \
-  && update-ca-certificates \
   && ./install_aocl.sh /opt/aocl \
   && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \

--- a/container/ubuntu-20.04-clang/Dockerfile
+++ b/container/ubuntu-20.04-clang/Dockerfile
@@ -3,11 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM ghcr.io/intel/fpga-runtime-for-opencl/certificates AS certificates
-
 FROM ubuntu:20.04
-
-COPY --from=certificates /*.crt /usr/local/share/ca-certificates/
 
 ARG clang_installdir=/opt/clang
 ARG clang_version=13.0.0
@@ -30,7 +26,6 @@ RUN apt-get -y update \
   sudo \
   xz-utils \
   && apt-get -y clean \
-  && update-ca-certificates \
   && curl -L -o "$clang_archive" "$clang_archive_url" \
   && curl -L -o "$clang_archive_sig" "$clang_archive_sig_url" \
   && gpgv --keyring "$PWD/tstellar.gpg" "$clang_archive_sig" "$clang_archive" \

--- a/container/ubuntu-20.04-dev/Dockerfile
+++ b/container/ubuntu-20.04-dev/Dockerfile
@@ -3,11 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM ghcr.io/intel/fpga-runtime-for-opencl/certificates AS certificates
-
 FROM ubuntu:20.04
-
-COPY --from=certificates /*.crt /usr/local/share/ca-certificates/
 
 WORKDIR /work
 
@@ -31,7 +27,6 @@ RUN apt-get -y update \
   sudo \
   zlib1g-dev \
   && apt-get -y clean \
-  && update-ca-certificates \
   && ./install_aocl.sh /opt/aocl \
   && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \


### PR DESCRIPTION
This ensures that container images can be built locally, i.e., without
prerequisites that require access to the GitHub package registry.