### PR TITLE
Limit building containers on push to main branch

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -30,6 +30,8 @@ permissions:
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '.github/workflows/container.yml'
       - 'container/**'


### PR DESCRIPTION
This avoids building unused containers on push to release branches.