### PR TITLE
Use default new C++11 ABI for std::string and std::list in libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,7 +196,6 @@ set_target_properties(acl_objs PROPERTIES
 target_compile_features(acl_objs PRIVATE cxx_std_11)
 # These compile_definitions need to be public, since we're building an OBJECT library (?)
 target_compile_definitions(acl_objs PUBLIC
-  _GLIBCXX_USE_CXX11_ABI=0
   ACL_SUPPORT_DOUBLE=0
   ACL_HAS_STDLIB_STDIO
   CL_USE_DEPRECATED_OPENCL_1_0_APIS=1

--- a/src/acl_hal_mmd.cpp
+++ b/src/acl_hal_mmd.cpp
@@ -763,7 +763,7 @@ cl_bool l_load_board_libraries(cl_bool load_libraries) {
 cl_bool l_load_board_libraries(cl_bool load_libraries) {
   // Keeping the old path for backward compatibility
   std::string board_vendor_path_old = "/opt/Intel/OpenCL_boards/";
-  std::string board_vendor_path;
+  std::string board_vendor_path = "/opt/Intel/OpenCL/Boards/";
   auto *customer_board_vendor_path = acl_getenv("ACL_BOARD_VENDOR_PATH");
   acl_assert_locked();
 
@@ -774,9 +774,6 @@ cl_bool l_load_board_libraries(cl_bool load_libraries) {
     // append the '/' to the end of the customer_board_vendor_path
     // and load it to board_vendor_path
     board_vendor_path = customer_board_vendor_path + std::string("/");
-  } else {
-    // use the default path
-    board_vendor_path = "/opt/Intel/OpenCL/Boards/";
   }
 
   ACL_HAL_DEBUG_MSG_VERBOSE(1, "Intel(R) FPGA Board Vendor Path: %s\n",

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,6 @@ add_executable(acl_test
 set_target_properties(acl_test PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_features(acl_test PRIVATE cxx_std_11)
 target_compile_definitions(acl_test PRIVATE
-  _GLIBCXX_USE_CXX11_ABI=0
   "ACL_TARGET_BIT=${ACL_TARGET_BIT}"
   CL_USE_DEPRECATED_OPENCL_1_0_APIS=1
   CL_USE_DEPRECATED_OPENCL_1_1_APIS=1


### PR DESCRIPTION
This flag was once used as a work-around for very old linkers and has
not been needed for a long time. The ABI change does not affect the
public runtime ABI since the runtime does not expose any C++ symbols.
The ABI change does affect the size of OpenCL data structures, however
these are not exposed directly but only in the form of opaque pointers.

https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html