### PR TITLE
Add buffer location enum

### DIFF
--- a/src/acl_usm.cpp
+++ b/src/acl_usm.cpp
@@ -255,8 +255,8 @@ clDeviceMemAllocINTEL(cl_context context, cl_device_id device,
   cl_int status;
 
   // Use cl_mem for convenience
-  cl_mem usm_device_buffer =
-      clCreateBufferIntelFPGA(context, CL_MEM_READ_WRITE, size, NULL, &status);
+  cl_mem usm_device_buffer = clCreateBufferWithPropertiesINTEL(
+      context, NULL, CL_MEM_READ_WRITE, size, NULL, &status);
   if (status != CL_SUCCESS) {
     UNLOCK_BAIL_INFO(status, context, "Failed to allocate device memory");
   }


### PR DESCRIPTION
Sycl runtime calls clEnqueueWriteBuffer before clSetKernelArgs, this cause the buffer to be allocated on the device before knowing the right place of allocating the memory. As a result, later when kernel get invoked, the memory has to be copied from device's default global memory to the buffer location specified in kernel. This is an additional memory copy operation.

This extension does not interfer with the other way of setting buffer location (i.e through clSetKernelArgs). This property exist for integration with sycl runtime, not for pure opencl user to use. If opencl user wish to use this property, they have to make sure the buffer location passed into clCreateBufferWithPropertyINTEL has to match the one defined in kernel function interface, otherwise the extra memory copy issue will remain.

When resizing reserved allocation, we now have the information to allocate minimum amount of space required according to the property passed in.