### PR TITLE
Remove runtime assert for kernel finish_counter.

### DIFF
--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -1415,9 +1415,6 @@ void acl_kernel_if_update_status(acl_kernel_if *kern) {
                           &finish_counter);
       ACL_KERNEL_IF_DEBUG_MSG(kern, ":: Accelerator %d has %d finishes.\n", k,
                               finish_counter);
-      // At this point, this kernel has finish bit set on CSR
-      // Finish counter should be > 0
-      assert(finish_counter > 0);
     }
 
     for (i = 0; i < finish_counter; i++) {


### PR DESCRIPTION
Currently the kernel's finish_counter assert > 0 is called whenever there is a kernel interrupt sent. However the kernel interrupt could be sent whenever:
1. printf buffer is full
2. The kernel change state: init -> running -> finish/stall
3. clGetProfileInfoIntelFPGA is called

From the first reason, it already doesn't make sense to assert finish counter greater than 0, as is very possible for a printf buffer to be full before the kernel finishes.