### PR TITLE
Check pointer 'op' for NULL before dereferencing

### DIFF
--- a/src/acl_device_op.cpp
+++ b/src/acl_device_op.cpp
@@ -461,6 +461,8 @@ static unsigned
 l_get_devices_affected_for_op(acl_device_op_t *op, unsigned int physical_ids[],
                               acl_device_op_conflict_type_t conflicts[]) {
   unsigned int num_devices_affected = 0;
+  // The precondition of the function is device op must be active
+  assert(op);
   cl_event event = op->info.event;
   acl_assert_locked();
 


### PR DESCRIPTION
```
---------------------------------------------------------------------------
181 (Local) src/acl_device_op.cpp:464 RNPD.DEREF (1:Critical) Analyze
Suspicious dereference of pointer 'op' before NULL check at line 467
  * acl_device_op.cpp:464: 'op' is dereferenced.
  * acl_device_op.cpp:467: 'op' is checked for NULL.
Current status 'Analyze'

Summary: 1 Local
1 Total Issue(s)
```