### PR TITLE
Klocwork check null before dereference in acl_kernel_if

### DIFF
--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -949,6 +949,8 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
   if (kern->num_accel > 0) {
     kern->accel_job_ids =
         (int volatile **)acl_malloc(kern->num_accel * sizeof(int *));
+    assert(kern->accel_job_ids);
+
     kern->accel_invoc_queue_depth =
         (unsigned int *)acl_malloc(kern->num_accel * sizeof(unsigned int));
 

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -874,6 +874,7 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
     // Allocations for each kernel
     kern->accel_csr = (acl_kernel_if_addr_range *)acl_malloc(
         kern->num_accel * sizeof(acl_kernel_if_addr_range));
+    assert(kern->accel_csr);
     kern->accel_perf_mon = (acl_kernel_if_addr_range *)acl_malloc(
         kern->num_accel * sizeof(acl_kernel_if_addr_range));
     kern->accel_num_printfs =

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -958,6 +958,7 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
     // Kernel IRQ is a separate thread. Need to use circular buffer to make this
     // multithread safe.
     kern->accel_queue_front = (int *)acl_malloc(kern->num_accel * sizeof(int));
+    assert(kern->accel_queue_front);
     kern->accel_queue_back = (int *)acl_malloc(kern->num_accel * sizeof(int));
 
     for (unsigned a = 0; a < kern->num_accel; ++a) {

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -960,6 +960,7 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
     kern->accel_queue_front = (int *)acl_malloc(kern->num_accel * sizeof(int));
     assert(kern->accel_queue_front);
     kern->accel_queue_back = (int *)acl_malloc(kern->num_accel * sizeof(int));
+    assert(kern->accel_queue_back);
 
     for (unsigned a = 0; a < kern->num_accel; ++a) {
       unsigned int max_same_accel_launches =

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -877,6 +877,7 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
     assert(kern->accel_csr);
     kern->accel_perf_mon = (acl_kernel_if_addr_range *)acl_malloc(
         kern->num_accel * sizeof(acl_kernel_if_addr_range));
+    assert(kern->accel_perf_mon);
     kern->accel_num_printfs =
         (unsigned int *)acl_malloc(kern->num_accel * sizeof(unsigned int));
 

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -880,6 +880,7 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
     assert(kern->accel_perf_mon);
     kern->accel_num_printfs =
         (unsigned int *)acl_malloc(kern->num_accel * sizeof(unsigned int));
+    assert(kern->accel_num_printfs);
 
     // The Kernel CSR registers
     // The new and improved config ROM give us the address *offsets* from

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -953,6 +953,7 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
 
     kern->accel_invoc_queue_depth =
         (unsigned int *)acl_malloc(kern->num_accel * sizeof(unsigned int));
+    assert(kern->accel_invoc_queue_depth);
 
     // Kernel IRQ is a separate thread. Need to use circular buffer to make this
     // multithread safe.


### PR DESCRIPTION
Fix the following klocwork issues in acl_kernel_if.cpp:

1. Pointer 'kern->accel_csr' returned from call to function 'acl_malloc' at line 875 may be NULL and may be dereferenced at line 886.
2. Pointer 'kern->accel_perf_mon' returned from call to function 'acl_malloc' at line 877 may be NULL and may be dereferenced at line 898.
3. Pointer 'kern->accel_num_printfs' returned from call to function 'acl_malloc' at line 879 may be NULL and may be dereferenced at line 908.
4. Pointer 'kern->accel_job_ids' returned from call to function 'acl_malloc' at line 947 may be NULL and will be dereferenced at line 962.
5. Pointer 'kern->accel_queue_front' returned from call to function 'acl_malloc' at line 954 may be NULL and will be dereferenced at line 964.
6. Pointer 'kern->accel_invoc_queue_depth' returned from call to function 'acl_malloc' at line 949 may be NULL and will be dereferenced at line 961. 
7. Pointer 'kern->accel_queue_back' returned from call to function 'acl_malloc' at line 955 may be NULL and will be dereferenced at line 965.