### PR TITLE
Add OCL Core 3.0 clCreateImageWithProperties function

### DIFF
--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -1778,6 +1778,16 @@ ACL_EXPORT CL_API_ENTRY cl_mem CL_API_CALL clCreateImage(
   return clCreateImageIntelFPGA(context, flags, image_format, image_desc,
                                 host_ptr, errcode_ret);
 }
+
+ACL_EXPORT CL_API_ENTRY cl_mem CL_API_CALL clCreateImageWithProperties(
+    cl_context context, const cl_mem_properties *properties, cl_mem_flags flags,
+    const cl_image_format *image_format, const cl_image_desc *image_desc,
+    void *host_ptr, cl_int *errcode_ret) {
+  // Currently clCreateImageIntelFPGA accept no properties.
+  return clCreateImageIntelFPGA(context, flags, image_format, image_desc,
+                                host_ptr, errcode_ret);
+}
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable : 4100)

--- a/test/acl_mem_test.cpp
+++ b/test/acl_mem_test.cpp
@@ -281,9 +281,10 @@ MT_TEST(acl_mem, create_image_align) {
     CHECK_EQUAL(0, addr & (align_req - 1));
     clReleaseMemObject(image);
 
-    image = clCreateImage(m_context, CL_MEM_ALLOC_HOST_PTR, &image_format,
-                          &image_desc, 0, &status);
+    image = clCreateImageWithProperties(m_context, NULL, CL_MEM_ALLOC_HOST_PTR,
+                                        &image_format, &image_desc, 0, &status);
     CHECK_EQUAL(CL_SUCCESS, status);
+    assert(image);
     addr = (uintptr_t)image->block_allocation->range.begin;
     CHECK_EQUAL(0, addr & (align_req - 1));
     clReleaseMemObject(image);


### PR DESCRIPTION
As a part of the effort in upgrading opencl version

Currently the child function it calls receive no properties because as of now, user cannot create image with property.

Closes #90