### PR TITLE
Remove `please` in messages and documentations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 # We exclusively support Ninja as the generator used to build the project.
 if(NOT CMAKE_GENERATOR STREQUAL "Ninja")
-  message(FATAL_ERROR "unsupported cmake generator, please use `cmake -G Ninja`")
+  message(FATAL_ERROR "unsupported cmake generator, use `cmake -G Ninja` instead")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")

--- a/src/acl_auto_configure.cpp
+++ b/src/acl_auto_configure.cpp
@@ -206,7 +206,7 @@ bool acl_load_device_def_from_str(const std::string &config_str,
       err_ss << "Error: The accelerator hardware currently programmed is "
                 "incompatible with this\nversion of the runtime (" ACL_VERSION
                 " Commit " ACL_GIT_COMMIT ")."
-                " Please recompile the hardware with\nthe same version of the "
+                " Recompile the hardware with\nthe same version of the "
                 "compiler and program that onto the board.\n";
       err_str = err_ss.str();
     }

--- a/src/acl_context.cpp
+++ b/src/acl_context.cpp
@@ -585,7 +585,7 @@ static cl_int l_load_properties(cl_context context,
       override = override_deprecated;
       fprintf(stderr,
               "Warning: CL_CONTEXT_COMPILER_MODE_ALTERA has been deprecated. "
-              "Please use CL_CONTEXT_COMPILER_MODE_INTELFPGA instead.\n");
+              "Use CL_CONTEXT_COMPILER_MODE_INTELFPGA instead.\n");
     }
 
     if (override) {

--- a/src/acl_device_binary.cpp
+++ b/src/acl_device_binary.cpp
@@ -243,7 +243,7 @@ cl_int acl_device_binary_t::load_binary_pkg(int validate_compile_options,
       << "This binary targets the BSP variant " << pkg_board_str
       << ", while the FPGA has the BSP\n"
       << "variant " << dev_prog->device->def.autodiscovery_def.name << ".\n"
-      << "Please use the command 'aocl initialize' to load the matching BSP\n"
+      << "Use the command 'aocl initialize' to load the matching BSP\n"
       << "variant prior to invoking the host executable.";
   if (!acl_getenv("ACL_PCIE_PROGRAM_SKIP_BOARDNAME_CHECK")) {
     AND_CHECK(pkg_board_str == dev_prog->device->def.autodiscovery_def.name,

--- a/src/acl_globals.cpp
+++ b/src/acl_globals.cpp
@@ -87,7 +87,7 @@ const char *acl_get_offline_device_user_setting(int *use_offline_only_ret) {
     setting = setting_deprecated;
     if (0 == warn_depr1) {
       fprintf(stderr, "[Runtime Warning]: CL_CONTEXT_OFFLINE_DEVICE_ALTERA has "
-                      "been deprecated. Please use "
+                      "been deprecated. Use "
                       "CL_CONTEXT_OFFLINE_DEVICE_INTELFPGA instead.\n");
       warn_depr1 = 1;
     }
@@ -119,7 +119,7 @@ const char *acl_get_offline_device_user_setting(int *use_offline_only_ret) {
         setting = setting_deprecated;
         if (0 == warn_depr3) {
           fprintf(stderr, "[Runtime Warning]: CL_CONTEXT_MSIM_DEVICE_ALTERA "
-                          "has been deprecated. Please use "
+                          "has been deprecated. Use "
                           "CL_CONTEXT_MSIM_DEVICE_INTELFPGA instead.\n");
           warn_depr3 = 1;
         }

--- a/src/acl_hal_mmd.cpp
+++ b/src/acl_hal_mmd.cpp
@@ -1445,7 +1445,7 @@ int acl_hal_mmd_try_devices(cl_uint num_devices, const cl_device_id *devices,
                         "       This combination of BSPs is not supported by "
                         "the Intel(R) FPGA SDK for OpenCL(TM) runtime.\n");
                 fprintf(stderr,
-                        "       Please uninstall the incompatible BSP(s) using "
+                        "       Uninstall the incompatible BSP(s) using "
                         "\"aocl uninstall <board_package_path>\".\n");
                 failed_device_id = physical_device_id;
                 goto failed;

--- a/src/acl_hostch.cpp
+++ b/src/acl_hostch.cpp
@@ -268,7 +268,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReadPipeIntelFPGA(cl_mem pipe, void *ptr) {
   if (ptr == NULL) {
     acl_mutex_unlock(&(pipe->host_pipe_info->m_lock));
     ERR_RET(CL_INVALID_VALUE, pipe->context,
-            "Please provide a valid pointer to host data");
+            "Invalid pointer was provided to host data");
   }
 
   // Is the pipe bound to a channel yet? If not then return unsuccessfully
@@ -368,7 +368,7 @@ CL_API_ENTRY cl_int CL_API_CALL clWritePipeIntelFPGA(cl_mem pipe, void *ptr) {
   if (ptr == NULL) {
     acl_mutex_unlock(&(pipe->host_pipe_info->m_lock));
     ERR_RET(CL_INVALID_VALUE, pipe->context,
-            "Please provide a valid pointer to host data");
+            "Invalid pointer was provided to host data");
   }
 
   // If there is no queued op and the pipe is binded
@@ -472,7 +472,7 @@ CL_API_ENTRY void *CL_API_CALL clMapHostPipeIntelFPGA(cl_mem pipe,
   if (mapped_size == NULL) {
     acl_mutex_unlock(&(pipe->host_pipe_info->m_lock));
     BAIL_INFO(CL_INVALID_VALUE, pipe->context,
-              "Please provide a valid pointer for mapped_size argument");
+              "Invalid pointer was provided for mapped_size argument");
   }
   *mapped_size = 0;
 

--- a/test/acl_auto_configure_test.cpp
+++ b/test/acl_auto_configure_test.cpp
@@ -877,7 +877,7 @@ TEST(auto_configure, bad_config) {
       std::string("Error: The accelerator hardware currently programmed is "
                   "incompatible with this\nversion of the runtime (" ACL_VERSION
                   " Commit " ACL_GIT_COMMIT
-                  "). Please recompile the hardware with\nthe same version of "
+                  "). Recompile the hardware with\nthe same version of "
                   "the compiler and program that onto the board.\n"),
 
       // Bad workgroup/workitem_invariant combination


### PR DESCRIPTION
Avoid using please in technical documentations according to https://www.sitepoint.com/making-demands-when-to-say-please-in-instructions-and-ctas/

Thanks to @dseynhae for pointing this out, and thanks @pcolberg for fixing other places!