### PR TITLE
Support early print buffer flushing in debug mode

### DIFF
--- a/include/acl_hal.h
+++ b/include/acl_hal.h
@@ -63,7 +63,7 @@ typedef void (*acl_device_update_callback)(
     unsigned physical_device_id, CL_EXCEPTION_TYPE_INTEL exception_type,
     void *user_private_info, size_t user_cb);
 typedef void (*acl_process_printf_buffer_callback)(int activation_id, int size,
-                                                   int stalled);
+                                                   int debug_dump_printf);
 ///@}
 
 typedef unsigned int mem_properties_t;

--- a/include/acl_kernel_if.h
+++ b/include/acl_kernel_if.h
@@ -50,6 +50,9 @@ typedef struct {
 
   // Track which of the kernels is the autorun profiling kernel (-1 if none)
   int autorun_profiling_kernel_id;
+
+  // Track debug printf activity
+  time_ns last_printf_dump = 0;
 } acl_kernel_if;
 
 // *********************** Public functions **************************

--- a/include/acl_types.h
+++ b/include/acl_types.h
@@ -922,6 +922,10 @@ typedef struct _cl_kernel {
   // Eventually this should be an array of ACLDeviceBinaries similar
   // to how cl_program contains an array of dev_prog.
   const acl_device_binary_t *dev_bin;
+
+  // In ACL_HAL_DEBUG mode, printf buffer could be dumped before Kernel ends
+  // Therefore, we need to keep track of how much data has been processed.
+  size_t processed_printf_buffer_size;
 } _cl_kernel;
 
 ACL_DECLARE_CL_OBJECT_ALLOC_FUNCTIONS(cl_kernel);
@@ -1346,6 +1350,10 @@ typedef struct {
   // it sees the CL_COMPLETE status for the first time, but it won't
   // change after that.
   cl_uint num_printf_bytes_pending;
+
+  // Indicate whether this operation is dumping printf buffer before the Kernel
+  // for debug purpose
+  int debug_dump_printf = 0;
 } acl_device_op_info_t;
 
 // An operation to be performed on a device.

--- a/src/acl_kernel.cpp
+++ b/src/acl_kernel.cpp
@@ -2419,6 +2419,9 @@ static int l_init_kernel(cl_kernel kernel, cl_program program,
   // Check if there are printfs in the kernel
   kernel->printf_device_buffer = 0; // Default is none.
   kernel->printf_device_ptr = 0;    // Default is none.
+  // Keep track of already processed buffer size
+  // It will be reset when the buffer is full and dumped.
+  kernel->processed_printf_buffer_size = 0;
   if (!accel_def->printf_format_info.empty()) {
     auto gmem_idx = static_cast<size_t>(
         acl_get_default_memory(kernel->dev_bin->get_devdef()));

--- a/test/acl_device_op_test.cpp
+++ b/test/acl_device_op_test.cpp
@@ -363,6 +363,7 @@ TEST(device_op, submit_action) {
   CHECK(l_launch_kernel == the_call);
   CHECK_EQUAL(0, unblocked);
   CHECK_EQUAL(0, op->info.num_printf_bytes_pending);
+  CHECK_EQUAL(0, op->info.debug_dump_printf);
   CHECK(prev < (latest = op->timestamp[CL_SUBMITTED]));
   prev = latest;
 
@@ -400,6 +401,7 @@ TEST(device_op, submit_action) {
   op->info.type = ACL_DEVICE_OP_KERNEL;
   op->status = op->execution_status = CL_RUNNING; // Required
   op->info.num_printf_bytes_pending = 1;
+  CHECK_EQUAL(0, op->info.debug_dump_printf);
   acl_submit_device_op(&m_doq, op);
   CHECK_EQUAL(ACL_DEVICE_OP_KERNEL, submit_kind);
   CHECK_EQUAL(op->info.type, submit_kind);
@@ -409,6 +411,7 @@ TEST(device_op, submit_action) {
   CHECK_EQUAL(1, unblocked);
   CHECK_EQUAL(0, op->info.num_printf_bytes_pending); // no longer marked as
                                                      // stalled on printf.
+  CHECK_EQUAL(0, op->info.debug_dump_printf);
   // We didn't change the submit time.
   CHECK_EQUAL(kernel_submit_time, op->timestamp[CL_SUBMITTED]);
   prev = latest;
@@ -419,6 +422,7 @@ TEST(device_op, submit_action) {
   op->info.type = ACL_DEVICE_OP_KERNEL;
   op->status = op->execution_status = CL_COMPLETE; // Required
   op->info.num_printf_bytes_pending = 1;
+  CHECK_EQUAL(0, op->info.debug_dump_printf);
   acl_submit_device_op(&m_doq, op);
   CHECK_EQUAL(ACL_DEVICE_OP_KERNEL, submit_kind);
   CHECK_EQUAL(op->info.type, submit_kind);
@@ -428,6 +432,7 @@ TEST(device_op, submit_action) {
   CHECK_EQUAL(1, unblocked);
   CHECK_EQUAL(0, op->info.num_printf_bytes_pending); // no longer marked as
                                                      // stalled on printf.
+  CHECK_EQUAL(0, op->info.debug_dump_printf);
   // We didn't change the submit time.
   CHECK_EQUAL(kernel_submit_time, op->timestamp[CL_SUBMITTED]);
   prev = latest;


### PR DESCRIPTION
Added a flow to flush printf() buffer before the Kernel ends. This will be helpful for debugging a hang Kernel. The Runtime periodically polls from the device and process the printf buffer from the last processed point.



If ACL_HAL_DEBUG = 1 and the Kernel is Hang, Kernel status (existing feature) and printf buffer will be flushed to stdout every 10 seconds (approximately). The thread will run if there are spare cycles.

If ACL_HAL_DEBUG = 3, Kernel status and printf buffer will flushed every 10 seconds, even the Kernel isn't hung.

The behavior of printf() is not altered in non-debug mode.

## Sample output

```
  Kernel  0 Status: 0x00048000 running:: Accelerator 0 printf buffer size is 160.
:: Calling acl_process_printf_buffer_fn with activation_id=1 and printf_size=160.


Previously processed buffer size is 0 
Another test string 14
This is a test
Another test string 11
Another test string 12
Another test string 13
  Kernel  0 Status: 0x00048000 running:: Accelerator 0 printf buffer size is 160.
:: Calling acl_process_printf_buffer_fn with activation_id=1 and printf_size=160.


Previously processed buffer size is 160 
All Printf() buffer has already been dumped
```

## ToDo
- [x] Fix Klocwork if applicable
- [x] Run Clang format
- [x] manual testing
- [x] Clear commit messages and Rebase
- [x] Run existing regtest to ensure existing feature still passes
- [ ] Create a new regtest to test this specific feature