### PR TITLE
Add Thread Sanitizer CI/CD

### DIFF
--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -1,0 +1,99 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: thread sanitizer
+
+# https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/
+permissions:
+  # Grant read permissions to repository in case it is not a forked public
+  # repository, but a private repository that was created manually.
+  contents: read
+
+  # Grant read permissions to private container images.
+  packages: read
+
+on:
+  push:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!**/.clang-format'
+      - '!**/COPYING'
+      - '!**/LICENSE'
+      - '!.github/**'
+      - '.github/workflows/tsan.yml'
+      - '!.gitignore'
+      - '!cmake/manifests/**'
+      - 'cmake/manifests/linux/**'
+      - '!container/**'
+      - '!docs/**'
+      - '!scripts/**'
+
+  pull_request:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!**/.clang-format'
+      - '!**/COPYING'
+      - '!**/LICENSE'
+      - '!.github/**'
+      - '.github/workflows/tsan.yml'
+      - '!.gitignore'
+      - '!cmake/manifests/**'
+      - 'cmake/manifests/linux/**'
+      - '!container/**'
+      - '!docs/**'
+      - '!scripts/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    container:
+      image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-20.04-dev:main
+
+    continue-on-error: true
+
+    steps:
+      - name: change ownership of workspace to current user
+        run: sudo chown -R build:build .
+
+      - name: checkout code
+        uses: actions/checkout@v2
+
+      - name: query distribution
+        run: cat /etc/os-release
+
+      - name: create build directory
+        run: mkdir build
+
+      - name: create build files
+        run: |
+          cd build
+          cmake -G Ninja .. -DCMAKE_BUILD_TYPE=Debug -DACL_TSAN=ON
+        env:
+          CC: gcc
+          CXX: g++
+
+      - name: build runtime
+        run: |
+          cd build
+          ninja -v -k0
+
+      - name: test runtime
+        run: |
+          cd build
+          ctest -V
+
+      - name: tsan result
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: tsan-report
+          path: build/Testing/Temporary/LastTest.log
+
+      - name: revert ownership of workspace to root
+        run: sudo chown -R root:root .
+        if: always()


### PR DESCRIPTION
ThreadSanitizer is a tool that detects data races. It consists of a compiler instrumentation module and a run-time library.

This help us to identify race conditions within the program. It will have greater coverage if we can mock MMD.

Addresses #38