### PR TITLE
Include cl_ext.h instead of deprecated cl_ext_intel.h

### DIFF
--- a/include/acl.h
+++ b/include/acl.h
@@ -9,7 +9,7 @@
 #include <string>
 #include <vector>
 
-#include <CL/cl_ext_intel.h>
+#include <CL/cl_ext.h>
 
 #include "acl_visibility.h"
 

--- a/include/acl_svm.h
+++ b/include/acl_svm.h
@@ -4,7 +4,6 @@
 #ifndef ACL_SVM_H
 #define ACL_SVM_H
 
-#include <CL/cl_ext.h>
 #include <CL/opencl.h>
 
 #include "acl_types.h"

--- a/include/acl_usm.h
+++ b/include/acl_usm.h
@@ -4,8 +4,6 @@
 #ifndef ACL_USM_H
 #define ACL_USM_H
 
-#include <CL/cl_ext.h>
-#include <CL/cl_ext_intel.h>
 #include <CL/opencl.h>
 
 #include "acl_types.h"

--- a/src/acl_icd_dispatch.cpp
+++ b/src/acl_icd_dispatch.cpp
@@ -5,7 +5,6 @@
 #include <string.h>
 
 // External library headers.
-#include <CL/cl_ext_intel.h>
 #include <CL/cl_ext_intelfpga.h>
 #include <CL/opencl.h>
 

--- a/src/acl_kernel.cpp
+++ b/src/acl_kernel.cpp
@@ -11,8 +11,6 @@
 #include <vector>
 
 // External library headers.
-#include <CL/cl_ext.h>
-#include <CL/cl_ext_intel.h>
 #include <CL/opencl.h>
 #include <acl_hash/acl_hash.h>
 #include <acl_threadsupport/acl_threadsupport.h>

--- a/src/acl_usm.cpp
+++ b/src/acl_usm.cpp
@@ -11,7 +11,6 @@
 #include <unordered_set>
 
 // External library headers.
-#include <CL/cl_ext_intel.h>
 #include <CL/opencl.h>
 
 // Internal headers.

--- a/test/fake_bsp/CMakeLists.txt
+++ b/test/fake_bsp/CMakeLists.txt
@@ -4,6 +4,9 @@
 add_library(fakegoodbsp SHARED fakegoodbsp.cpp)
 target_include_directories(fakegoodbsp PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_link_libraries(fakegoodbsp PRIVATE acl_headers CppUTest test_acl_test_header)
+target_compile_definitions(fakegoodbsp PRIVATE
+  CL_TARGET_OPENCL_VERSION=300
+  )
 if(WIN32)
   target_compile_definitions(fakegoodbsp PRIVATE AOCL_MMD_CALL=__declspec\(dllexport\))
 endif()
@@ -11,6 +14,9 @@ endif()
 add_library(missingfuncbsp SHARED missingfuncbsp.cpp)
 target_include_directories(missingfuncbsp PRIVATE "${CMAKE_SOURCE_DIR}/src")
 target_link_libraries(missingfuncbsp PRIVATE acl_headers CppUTest test_acl_test_header)
+target_compile_definitions(missingfuncbsp PRIVATE
+  CL_TARGET_OPENCL_VERSION=300
+  )
 if(WIN32)
   target_compile_definitions(missingfuncbsp PRIVATE AOCL_MMD_CALL=__declspec\(dllexport\))
 endif()


### PR DESCRIPTION
Note that opencl.h already includes cl_ext.h

This resolves warnings introduced with the OpenCL headers update.

https://github.com/intel/fpga-runtime-for-opencl/pull/62

```
../include/CL/cl_ext_intel.h:19:105: note: #pragma message: The Intel extensions have been moved into cl_ext.h.  Please include cl_ext.h directly.
 #pragma message("The Intel extensions have been moved into cl_ext.h.  Please include cl_ext.h directly.")
```

Closes https://github.com/intel/fpga-runtime-for-opencl/issues/66