### PR TITLE
Install OpenCL header CL/cl_layer.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ install(FILES
     include/CL/cl_gl_ext.h
     include/CL/cl_half.h
     include/CL/cl_icd.h
+    include/CL/cl_layer.h
     include/CL/cl_platform.h
     include/CL/cl_va_api_media_sharing_intel.h
     include/CL/cl_version.h

--- a/cmake/manifests/linux/install_manifest.txt
+++ b/cmake/manifests/linux/install_manifest.txt
@@ -29,6 +29,7 @@
 /fpga-runtime-for-opencl/include/CL/cl_gl_ext.h
 /fpga-runtime-for-opencl/include/CL/cl_half.h
 /fpga-runtime-for-opencl/include/CL/cl_icd.h
+/fpga-runtime-for-opencl/include/CL/cl_layer.h
 /fpga-runtime-for-opencl/include/CL/cl_platform.h
 /fpga-runtime-for-opencl/include/CL/cl_va_api_media_sharing_intel.h
 /fpga-runtime-for-opencl/include/CL/cl_version.h

--- a/cmake/manifests/linux/install_manifest_CL.txt
+++ b/cmake/manifests/linux/install_manifest_CL.txt
@@ -11,6 +11,7 @@
 /fpga-runtime-for-opencl/include/CL/cl_gl_ext.h
 /fpga-runtime-for-opencl/include/CL/cl_half.h
 /fpga-runtime-for-opencl/include/CL/cl_icd.h
+/fpga-runtime-for-opencl/include/CL/cl_layer.h
 /fpga-runtime-for-opencl/include/CL/cl_platform.h
 /fpga-runtime-for-opencl/include/CL/cl_va_api_media_sharing_intel.h
 /fpga-runtime-for-opencl/include/CL/cl_version.h

--- a/cmake/manifests/windows/install_manifest.txt
+++ b/cmake/manifests/windows/install_manifest.txt
@@ -30,6 +30,7 @@ C:/fpga-runtime-for-opencl/include/CL/cl_gl.h
 C:/fpga-runtime-for-opencl/include/CL/cl_gl_ext.h
 C:/fpga-runtime-for-opencl/include/CL/cl_half.h
 C:/fpga-runtime-for-opencl/include/CL/cl_icd.h
+C:/fpga-runtime-for-opencl/include/CL/cl_layer.h
 C:/fpga-runtime-for-opencl/include/CL/cl_platform.h
 C:/fpga-runtime-for-opencl/include/CL/cl_va_api_media_sharing_intel.h
 C:/fpga-runtime-for-opencl/include/CL/cl_version.h

--- a/cmake/manifests/windows/install_manifest_CL.txt
+++ b/cmake/manifests/windows/install_manifest_CL.txt
@@ -11,6 +11,7 @@ C:/fpga-runtime-for-opencl/include/CL/cl_gl.h
 C:/fpga-runtime-for-opencl/include/CL/cl_gl_ext.h
 C:/fpga-runtime-for-opencl/include/CL/cl_half.h
 C:/fpga-runtime-for-opencl/include/CL/cl_icd.h
+C:/fpga-runtime-for-opencl/include/CL/cl_layer.h
 C:/fpga-runtime-for-opencl/include/CL/cl_platform.h
 C:/fpga-runtime-for-opencl/include/CL/cl_va_api_media_sharing_intel.h
 C:/fpga-runtime-for-opencl/include/CL/cl_version.h


### PR DESCRIPTION
This amends https://github.com/intel/fpga-runtime-for-opencl/pull/62

OpenCL layers are an experimental feature which we don't use, but there
is no downside to installing the header for the sake of completeness.

https://github.com/KhronosGroup/OpenCL-ICD-Loader/blob/cd7d07cfa667d8d959b4272be45cf217a65c2948/README.md#about-layers