### PR TITLE
Load libz.so.1

### DIFF
--- a/lib/pkg_editor/src/zlib.c
+++ b/lib/pkg_editor/src/zlib.c
@@ -86,6 +86,10 @@ static void *zlib_load_library() {
   void *const library = (void *)LoadLibraryA(WINDOWS_ZLIB_PATH);
   return library;
 #else
+  void *const dlopen_handle = dlopen("libz.so.1", RTLD_NOW);
+  if (dlopen_handle) {
+    return dlopen_handle;
+  }
   return dlopen("libz.so", RTLD_NOW);
 #endif
 }


### PR DESCRIPTION
Many OSs have only libz.so.1 but no libz.so, so when loading zlib, want to check both and load libz.so.1 first, and then double check libz.so if that fails.