### PR TITLE
Migrate from CentOS to Rocky Linux

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         container:
-          - centos-8-dev
+          - rockylinux-8-dev
           - debian-11-arm-dev
           - opensuse-leap-15-dev
           - ubuntu-18.04-dev

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Linux
 
--   Red Hat Enterprise Linux (RHEL)\* or CentOS\* 8
+-   Red Hat Enterprise Linux (RHEL)\* or Rocky Linux\* 8
 -   SUSE Linux Enterprise Server (SLES)\* or openSUSE Leap\* 15
 -   Ubuntu\* 18.04 or 20.04 LTS
 -   GCC 7.4.0 and higher
@@ -134,7 +134,7 @@ ctest -V
 -   On Linux, `aoc` requires the `libtinfo.so.5` library, which you can install
     using one of the following OS-specific commands:
 
-    -   Red Hat Enterprise Linux (RHEL)\* or CentOS\* 8:
+    -   Red Hat Enterprise Linux (RHEL)\* or Rocky Linux\* 8:
 
         ```
         sudo yum install ncurses-compat-libs-6.1

--- a/container/rockylinux-8-dev/Dockerfile
+++ b/container/rockylinux-8-dev/Dockerfile
@@ -3,7 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM centos:8
+FROM rockylinux:8
 
 WORKDIR /work
 
@@ -11,8 +11,9 @@ WORKDIR /work
 # to extend the `paths` on which the workflow runs.
 COPY scripts/. ./
 
-RUN sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo \
-  && grep '^enabled=1$' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo \
+RUN \
+  sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/Rocky-PowerTools.repo \
+  && grep '^enabled=1$' /etc/yum.repos.d/Rocky-PowerTools.repo \
   && yum -y upgrade \
   && yum -y install \
   cmake \


### PR DESCRIPTION
CentOS 8 was discontinued and replaced by a rolling, continuously
updated distribution, CentOS stream that is always ahead of RHEL 8.

The Intel oneAPI Base Toolkit supports Rocky Linux 8 instead.

https://blog.centos.org/2020/12/future-is-centos-stream/
https://www.intel.com/content/www/us/en/developer/articles/system-requirements/intel-oneapi-base-toolkit-system-requirements.html