### PR TITLE
Fix TSAN data races

### DIFF
--- a/test/acl_command_queue_test.cpp
+++ b/test/acl_command_queue_test.cpp
@@ -387,8 +387,6 @@ MT_TEST(acl_command_queue, create_with_properties) {
     CHECK_EQUAL(CL_SUCCESS, clReleaseCommandQueue(cq));
     CHECK_EQUAL(1, acl_ref_count(cq));
     CHECK_EQUAL(CL_SUCCESS, clReleaseCommandQueue(cq));
-    CHECK_EQUAL(0, acl_ref_count(cq));
-    ACL_LOCKED(CHECK(!acl_command_queue_is_valid(cq)));
 
     // wait until all threads do their checks on the 0-ref-count command
     // queue before starting the next iteration of the loop and creating new
@@ -421,8 +419,6 @@ MT_TEST(acl_command_queue, create_with_properties) {
       CHECK_EQUAL(CL_SUCCESS, clReleaseCommandQueue(cq));
       CHECK_EQUAL(1, acl_ref_count(cq));
       CHECK_EQUAL(CL_SUCCESS, clReleaseCommandQueue(cq));
-      CHECK_EQUAL(0, acl_ref_count(cq));
-      ACL_LOCKED(CHECK(!acl_command_queue_is_valid(cq)));
 
       // wait until all threads do their checks on the 0-ref-count command
       // queue before starting the next iteration of the loop and creating new
@@ -674,15 +670,6 @@ MT_TEST(acl_command_queue, after_context_release) {
   // Should be able to release all the way.
   CHECK_EQUAL(CL_SUCCESS, clReleaseCommandQueue(cq0));
   CHECK_EQUAL(CL_SUCCESS, clReleaseCommandQueue(cq1));
-  CHECK_EQUAL(0, acl_ref_count(cq0));
-  CHECK_EQUAL(0, acl_ref_count(cq1));
-
-  ACL_LOCKED(CHECK(!acl_command_queue_is_valid(cq0)));
-  ACL_LOCKED(CHECK(!acl_command_queue_is_valid(cq1)));
-
-  // And once it's gone, it's gone.
-  CHECK_EQUAL(CL_INVALID_COMMAND_QUEUE, clReleaseCommandQueue(cq0));
-  CHECK_EQUAL(CL_INVALID_COMMAND_QUEUE, clReleaseCommandQueue(cq1));
 }
 
 // Main Event is in an OOO queue. It has a dependent event in an in-order queue.


### PR DESCRIPTION
As found in #71, tsan reported several issues in the acl_test

Currently when release command queue are called (which frees the memory) subsequent still checks the values at the same address which cause tsan to report heap-use-after-free.

The test after_context_release are moved upward to be the first test because ctest execute the test in reverse order of how they appear in the cpp file. Given after_context_release will release the command queue, they should be run last, i.e place at the top in the test.cpp file.

Prerequisit for #63 

Closes #71 