### PR TITLE
Add thread sanitizer option to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
 endif()
 
 # https://clang.llvm.org/docs/AddressSanitizer.html
+# https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003daddress
 option(ACL_WITH_ASAN "Build with address sanitizer" OFF)
 message(STATUS "Build with address sanitizer: ${ACL_WITH_ASAN}")
 if(ACL_WITH_ASAN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,20 @@ if(ACL_WITH_ASAN)
   endforeach()
 endif()
 
+# https://clang.llvm.org/docs/ThreadSanitizer.html
+# https://gcc.gnu.org/onlinedocs/gcc/Instrumentation-Options.html#index-fsanitize_003dthread
+option(ACL_TSAN "Build with thread sanitizer" OFF)
+message(STATUS "Build with thread sanitizer: ${ACL_TSAN}")
+if(ACL_TSAN)
+  foreach(lang C CXX)
+    if(CMAKE_${lang}_COMPILER_ID MATCHES "^(Clang|GNU)$")
+      set(CMAKE_${lang}_FLAGS "${CMAKE_${lang}_FLAGS} -fsanitize=thread -fno-omit-frame-pointer")
+    else()
+      message(FATAL_ERROR "cannot build with thread sanitizer due to unsupported ${lang} compiler")
+    endif()
+  endforeach()
+endif()
+
 include(CPack)
 include(CTest)
 


### PR DESCRIPTION
----------------------------------------------

Thread sanitizer (TSAN) is a tool that detect data races, deadlocks  between threads. (it also sometimes report heap-use-after-free in same thread check #71 for issues reported in current repo)

For more information, checkout https://clang.llvm.org/docs/ThreadSanitizer.html

Addresses #38 