### PR TITLE
Remove unused variable to avoid compiler warning

### DIFF
--- a/lib/acl_threadsupport/test/acl_threadsupport_test.cpp
+++ b/lib/acl_threadsupport/test/acl_threadsupport_test.cpp
@@ -442,7 +442,6 @@ TEST(condvar, wait_signal_with_timeout) {
   struct acl_condvar_s cc;
   acl_init_condvar(&cc);
 
-  int timedout = 0;
   acl_acquire_condvar(&cc);
   CHECK_EQUAL(1, acl_timed_wait_condvar(&cc, 1));
   CHECK_EQUAL(1, cc.timedout[0]);

--- a/test/acl_mem_test.cpp
+++ b/test/acl_mem_test.cpp
@@ -2809,7 +2809,6 @@ TEST(acl_mem, buffer_location_property) {
   size_t total_size = ACL_RANGE_SIZE(
       m_device[0]->def.autodiscovery_def.global_mem_defs[0].range);
   size_t bank_size = total_size / 2;
-  size_t small_size = bank_size / 1024;
 
   cl_mem_properties_intel props[] = {CL_MEM_ALLOC_BUFFER_LOCATION_INTEL, 0, 0};
   a = clCreateBufferWithPropertiesINTEL(m_context, props, 0, bank_size, 0,


### PR DESCRIPTION
```
../lib/acl_threadsupport/test/acl_threadsupport_test.cpp: In member function 'virtual void condvar_wait_signal_with_timeout_Test::testBody()':
../lib/acl_threadsupport/test/acl_threadsupport_test.cpp:445:7: warning: unused variable 'timedout' [-Wunused-variable]
   int timedout = 0;
       ^~~~~~~~

../test/acl_mem_test.cpp: In member function 'virtual void acl_mem_buffer_location_property_Test::testBody()':
../test/acl_mem_test.cpp:2812:10: warning: unused variable 'small_size' [-Wunused-variable]
   size_t small_size = bank_size / 1024;

```