### PR TITLE
Fix GCC warning: ignoring #pragma warning

### DIFF
--- a/test/acl_svm_test.cpp
+++ b/test/acl_svm_test.cpp
@@ -1,9 +1,14 @@
 // Copyright (C) 2014-2021 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 
-#pragma warning(push, 0)
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100) // unreferenced formal parameter
+#endif
 #include <CppUTest/TestHarness.h>
-#pragma warning(pop);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <CL/opencl.h>
 

--- a/test/acl_usm_test.cpp
+++ b/test/acl_usm_test.cpp
@@ -5,9 +5,14 @@
 // compiling for ARM
 #ifndef __arm__
 
-#pragma warning(push, 0)
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4100) // unreferenced formal parameter
+#endif
 #include <CppUTest/TestHarness.h>
-#pragma warning(pop);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <CL/opencl.h>
 


### PR DESCRIPTION
Guard suppression of MVSC unreferenced formal parameter warning.
    
https://github.com/intel/fpga-runtime-for-opencl/blob/aca879be71ca8f7e06a9d5bafbe5c79820bb9a3d/test/acl_command_queue_test.cpp#L4-L11

Prerequisite of https://github.com/intel/fpga-runtime-for-opencl/issues/85