### PR TITLE
acl_hash: fix signedness conversion warnings for internal tail buffer

### DIFF
--- a/lib/acl_hash/include/acl_hash/acl_hash.h
+++ b/lib/acl_hash/include/acl_hash/acl_hash.h
@@ -55,7 +55,7 @@ typedef struct {
   uint32_t h0, h1, h2, h3, h4;
   // The (len % 64) most recent bytes to be added.
   // tail[0] is the earliest data byte, and so on.
-  char tail[64];
+  unsigned char tail[64];
 } acl_hash_sha1_context_t;
 
 typedef struct {

--- a/lib/acl_hash/src/acl_hash.c
+++ b/lib/acl_hash/src/acl_hash.c
@@ -18,11 +18,12 @@
 //////////////////////////////
 // Local functions prototypes
 
-static void l_accum(acl_hash_sha1_context_t *c, const char *buf, size_t len);
-static void l_accum_block(acl_hash_sha1_context_t *c, const char *buf);
+static void l_accum(acl_hash_sha1_context_t *c, const unsigned char *buf,
+                    size_t len);
+static void l_accum_block(acl_hash_sha1_context_t *c, const unsigned char *buf);
 static void l_close(acl_hash_sha1_context_t *c, char *digest_buf);
 static uint32_t l_leftrotate(uint32_t v, unsigned bits);
-static uint32_t l_read_bigendian_i32(const char *buf);
+static uint32_t l_read_bigendian_i32(const unsigned char *buf);
 static void l_write_bigendian_hex_i32(uint32_t v, char *buf);
 
 //////////////////////////////
@@ -53,7 +54,7 @@ int acl_hash_add(acl_hash_context_t *ctx, const void *buf, size_t len) {
     return 0;
   }
 
-  l_accum(&(ctx->alg.sha1), (char *)buf, len);
+  l_accum(&(ctx->alg.sha1), (unsigned char *)buf, len);
 
   return 1;
 }
@@ -87,7 +88,8 @@ int acl_hash_hexdigest(acl_hash_context_t *ctx, char *digest_buf,
 //////////////////////////////
 // Local functions
 
-static void l_accum(acl_hash_sha1_context_t *c, const char *buf, size_t len) {
+static void l_accum(acl_hash_sha1_context_t *c, const unsigned char *buf,
+                    size_t len) {
   size_t buf_idx = 0;
   size_t tail_idx = c->len & 63;
 
@@ -127,7 +129,8 @@ static void l_accum(acl_hash_sha1_context_t *c, const char *buf, size_t len) {
   }
 }
 
-static void l_accum_block(acl_hash_sha1_context_t *ctx, const char *buf) {
+static void l_accum_block(acl_hash_sha1_context_t *ctx,
+                          const unsigned char *buf) {
   unsigned i;
   uint32_t w[80];
   uint32_t a = ctx->h0;
@@ -180,7 +183,7 @@ static void l_accum_block(acl_hash_sha1_context_t *ctx, const char *buf) {
 }
 
 static void l_close(acl_hash_sha1_context_t *c, char *digest_buf) {
-  char extra[64];
+  unsigned char extra[64];
   unsigned i;
   unsigned raw_tail_len = (1 /* 1-byte */ + 8 /* length field */ + c->len) & 63;
   unsigned num_zero_fill_bytes = raw_tail_len > 0 ? (64 - raw_tail_len) : 0;
@@ -217,12 +220,12 @@ static uint32_t l_leftrotate(uint32_t v, unsigned bits) {
   return hi | lo;
 }
 
-static uint32_t l_read_bigendian_i32(const char *buf) {
+static uint32_t l_read_bigendian_i32(const unsigned char *buf) {
   // Need to cast to uchar so we don't sign extend when widening out to 32 bits.
-  uint32_t byte3 = (unsigned char)buf[0];
-  uint32_t byte2 = (unsigned char)buf[1];
-  uint32_t byte1 = (unsigned char)buf[2];
-  uint32_t byte0 = (unsigned char)buf[3];
+  uint32_t byte3 = buf[0];
+  uint32_t byte2 = buf[1];
+  uint32_t byte1 = buf[2];
+  uint32_t byte0 = buf[3];
   uint32_t result = (byte3 << 24) | (byte2 << 16) | (byte1 << 8) | (byte0);
   return result;
 }


### PR DESCRIPTION
The signedness of `char` is platform-dependent, e.g., signed on the
platforms supported by the runtime, which causes the following integer
conversion warnings. `char` is appropriate for a buffer of characters,
whereas `unsigned char` is appropriate for a buffer of arbitrary bytes.

The signedness change only affects the internal implementation, i.e. the
internal tail buffer and the internal functions using that buffer. The
unit tests provide sufficient coverage to ensure correctness.

```
[2/14] Building C object lib/acl_hash/CMakeFiles/acl_hash.dir/src/acl_hash.c.o
../lib/acl_hash/src/acl_hash.c: In function ‘l_close’:
../lib/acl_hash/src/acl_hash.c:189:14: warning: conversion to ‘char’ alters ‘int’ constant value [-Wconversion]
   extra[0] = 0x80; // append '1' bit. Assume big endian even within byte.
              ^~~~
../lib/acl_hash/src/acl_hash.c:199:20: warning: conversion to ‘char’ from ‘uint64_t {aka long unsigned int}’ may alter its value [-Wconversion]
     extra[7 - i] = user_bits & 0xff;
                    ^~~~~~~~~
```

Prerequisite of https://github.com/intel/fpga-runtime-for-opencl/issues/85