### PR TITLE
CppUTest: remove unused stub function in TestRegistry test

### DIFF
--- a/lib/CppUTest/test/TestRegistryTest.cpp
+++ b/lib/CppUTest/test/TestRegistryTest.cpp
@@ -31,9 +31,6 @@
 
 namespace
 {
-void stub()
-{
-}
 const int testLineNumber = 1;
 }
 


### PR DESCRIPTION
This is aligned with the current upstream version of this file:

https://github.com/cpputest/cpputest/blob/a1913dec36d277fd3d169a323b7c0d2b11950c43/tests/CppUTest/TestRegistryTest.cpp#L33-L36

```
[61/113] Building CXX object lib/CppUTest/test/CMakeFiles/CppUTestTests.dir/TestRegistryTest.cpp.o
../lib/CppUTest/test/TestRegistryTest.cpp:34:6: warning: ‘void {anonymous}::stub()’ defined but not used [-Wunused-function]
 void stub()
      ^~~~
```

Prerequisite of https://github.com/intel/fpga-runtime-for-opencl/issues/85