### PR TITLE
CppUTest: fix integer conversion warning in gettid()

### DIFF
--- a/lib/CppUTest/src/UtestPlatformGcc.cpp
+++ b/lib/CppUTest/src/UtestPlatformGcc.cpp
@@ -56,7 +56,7 @@
 // kernel 2.4.11. Library support was added in glibc 2.30. (Earlier
 // glibc versions did not provide a wrapper for this system call,
 // necessitating the use of syscall(2).)
-static inline pid_t gettid(void) { return syscall( __NR_gettid ); }
+static inline pid_t gettid(void) { return (pid_t)syscall(__NR_gettid); }
 #endif
 
 #include "CppUTest/PlatformSpecificFunctions.h"


### PR DESCRIPTION
The cast is required since syscall() provides a generalized interface.

See, e.g. https://github.com/elogind/elogind/blob/06e702c9dafa3ea1dd6df8ee8cb4dcf417a0d442/src/basic/missing_syscall.h#L76-L87

```
[19/113] Building CXX object lib/CppUTest/CMakeFiles/CppUTest.dir/src/UtestPlatformGcc.cpp.o
../lib/CppUTest/src/UtestPlatformGcc.cpp: In function ‘pid_t gettid()’:
../lib/CppUTest/src/UtestPlatformGcc.cpp:59:50: warning: conversion to ‘pid_t {aka int}’ from ‘long int’ may alter its value [-Wconversion]
 static inline pid_t gettid(void) { return syscall( __NR_gettid ); }
                                           ~~~~~~~^~~~~~~~~~~~~~~
```

Prerequisite of #85