### PR TITLE
Check if device support heterogeneous memory

### DIFF
--- a/include/acl_platform.h
+++ b/include/acl_platform.h
@@ -21,6 +21,7 @@ extern int platform_owner_tid;
 void acl_init_platform(void);
 void acl_finalize_init_platform(unsigned int num_devices,
                                 const cl_device_id *devices);
+const char *acl_platform_extensions(void);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/src/acl_platform.cpp
+++ b/src/acl_platform.cpp
@@ -257,6 +257,34 @@ int acl_platform_is_valid(cl_platform_id platform) {
   return platform == &acl_platform;
 }
 
+const char *acl_platform_extensions() {
+  return "cl_khr_byte_addressable_store" // yes, we have correct access to
+                                         // individual bytes!
+         " cles_khr_int64" // yes, we support 64-bit ints in the embedded
+                           // profile
+
+         " cl_khr_icd"
+#if ACL_SUPPORT_IMAGES == 1
+         " cl_khr_3d_image_writes"
+#endif
+#if ACL_SUPPORT_DOUBLE == 1
+         " cl_khr_fp64"
+#endif
+#ifdef ACL_120
+         " cl_khr_global_int32_base_atomics"
+         " cl_khr_global_int32_extended_atomics"
+         " cl_khr_local_int32_base_atomics"
+         " cl_khr_local_int32_extended_atomics"
+#endif
+#ifndef __arm__
+  // Add the following once all USM APIs are implemented, Intel publishes
+  // the spec, and published USM conformance tests pass
+  //" cl_intel_unified_shared_memory"
+#endif
+         " cl_intel_create_buffer_with_properties"
+         " cl_intel_mem_channel_property";
+}
+
 // Initialize the internal bookkeeping based on the system definition
 // provided to us.
 void acl_init_platform(void) {
@@ -298,31 +326,7 @@ void acl_init_platform(void) {
   // The extensions string specifies the extensions supported by our framework.
   // To add an extension, append a flag name and separate it from others using a
   // space.
-  acl_platform.extensions =
-      "cl_khr_byte_addressable_store" // yes, we have correct access to
-                                      // individual bytes!
-      " cles_khr_int64" // yes, we support 64-bit ints in the embedded profile
-
-      " cl_khr_icd"
-#if ACL_SUPPORT_IMAGES == 1
-      " cl_khr_3d_image_writes"
-#endif
-#if ACL_SUPPORT_DOUBLE == 1
-      " cl_khr_fp64"
-#endif
-#ifdef ACL_120
-      " cl_khr_global_int32_base_atomics"
-      " cl_khr_global_int32_extended_atomics"
-      " cl_khr_local_int32_base_atomics"
-      " cl_khr_local_int32_extended_atomics"
-#endif
-#ifndef __arm__
-  // Add the following once all USM APIs are implemented, Intel publishes
-  // the spec, and published USM conformance tests pass
-  //" cl_intel_unified_shared_memory"
-#endif
-      " cl_intel_create_buffer_with_properties"
-      " cl_intel_mem_channel_property";
+  acl_platform.extensions = acl_platform_extensions();
 
   acl_platform.profile = "EMBEDDED_PROFILE";
   acl_platform.hal = acl_get_hal();

--- a/src/acl_platform.cpp
+++ b/src/acl_platform.cpp
@@ -282,7 +282,8 @@ const char *acl_platform_extensions() {
   //" cl_intel_unified_shared_memory"
 #endif
          " cl_intel_create_buffer_with_properties"
-         " cl_intel_mem_channel_property";
+         " cl_intel_mem_channel_property"
+         " cl_intel_mem_alloc_buffer_location";
 }
 
 // Initialize the internal bookkeeping based on the system definition

--- a/test/acl_device_test.cpp
+++ b/test/acl_device_test.cpp
@@ -324,10 +324,7 @@ MT_TEST(DeviceInfo, basic) {
     CHECK_EQUAL(CL_SUCCESS, clGetDeviceInfo(device, queries[i], str_size,
                                             &str[0], &size_ret));
 
-    if (queries[i] != CL_DEVICE_EXTENSIONS) {
-      // Non-empty result for most supported queries.
-      CHECK(size_ret > 0);
-    }
+    CHECK(size_ret > 0);
 
     switch (queries[i]) {
     case CL_DEVICE_VENDOR:

--- a/test/acl_device_test.cpp
+++ b/test/acl_device_test.cpp
@@ -14,6 +14,7 @@
 
 #include <acl.h>
 #include <acl_context.h>
+#include <acl_platform.h>
 #include <acl_types.h>
 #include <acl_util.h>
 
@@ -325,6 +326,10 @@ MT_TEST(DeviceInfo, basic) {
                                             &str[0], &size_ret));
 
     CHECK(size_ret > 0);
+
+    if (queries[i] == CL_DEVICE_EXTENSIONS) {
+      CHECK(strcmp(str, acl_platform_extensions()) == 0);
+    }
 
     switch (queries[i]) {
     case CL_DEVICE_VENDOR:


### PR DESCRIPTION

Currently sycl runtime is trying to distinguish whether buffer location is supported on the target device using lower level runtime getDeviceInfo call to determine it. However current runtime get device info does not yet support accepting the buffer location property yet, this change addes it.

The referenced sycl runtime PR: https://github.com/intel/llvm/pull/5604

This change is only needed if sycl runtime cannot come up with an workaround.