### PR TITLE
Fix download location of zlib archive

### DIFF
--- a/scripts/install_zlib.ps1
+++ b/scripts/install_zlib.ps1
@@ -9,7 +9,7 @@ Param(
   $version="1.2.11",
   $builddir="zlib-$version",
   $archive="zlib-$version.tar.gz",
-  $archive_url="https://zlib.net/$archive",
+  $archive_url="https://zlib.net/fossils/$archive",
   $sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 )
 

--- a/scripts/install_zlib.ps1
+++ b/scripts/install_zlib.ps1
@@ -6,11 +6,11 @@
 
 Param(
   [Parameter(Mandatory)]$installdir,
-  $version="1.2.11",
+  $version="1.2.12",
   $builddir="zlib-$version",
   $archive="zlib-$version.tar.gz",
   $archive_url="https://zlib.net/fossils/$archive",
-  $sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+  $sha256="91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
 )
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
zlib released a new version, which broke the link to the older version.

Use the archival link instead to avoid future breakage.

Signed-off-by: Peter Colberg <peter.colberg@intel.com>