### PR TITLE
Backport non-code commits to 2022.2

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - centos-8-dev
+          - rockylinux-8-dev
           - opensuse-leap-15-dev
           - ubuntu-18.04-dev
           - ubuntu-20.04-dev

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         container:
-          - centos-8-dev
+          - rockylinux-8-dev
           - debian-11-arm-dev
           - opensuse-leap-15-dev
           - ubuntu-18.04-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,48 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
+## [2022.2] - 2022-04-01
+
 ### Added
+
+- Document running unit tests individually ([#35]).
+- Document internal use of pre-C++11 standard library ABI ([#31], [#39]).
+- Document recommended settings for forked repository ([#44]).
+- Implement OpenCL Core 3.0 clCreateBufferWithProperties ([#53]).
+- Document running clang-format ([#60]).
+- Document git identity setup ([#70]).
+
 ### Changed
-### Deprecated
-### Removed
+
+- Support Rocky Linux 8 instead of CentOS 8 ([#72], [#73]).
+
 ### Fixed
 
 - Simulation of systems with multiple global memories ([#29]).
+- Explicitly require C++11 compiler support ([#47]).
+- Link failure with `-Wl,--no-undefined` ([#49]).
 
 ### Security
 
-[Unreleased]: https://github.com/intel/fpga-runtime-for-opencl/compare/v2022.1...HEAD
+- Check for null pointer before dereference ([#42], [#43]).
+- Update Windows installation script for zlib to 1.2.12 ([#96]).
+
+[2022.2]: https://github.com/intel/fpga-runtime-for-opencl/compare/v2022.1...v2022.2
 [#29]: https://github.com/intel/fpga-runtime-for-opencl/pull/29
+[#31]: https://github.com/intel/fpga-runtime-for-opencl/pull/31
+[#35]: https://github.com/intel/fpga-runtime-for-opencl/pull/35
+[#39]: https://github.com/intel/fpga-runtime-for-opencl/pull/39
+[#42]: https://github.com/intel/fpga-runtime-for-opencl/pull/42
+[#43]: https://github.com/intel/fpga-runtime-for-opencl/pull/43
+[#44]: https://github.com/intel/fpga-runtime-for-opencl/pull/44
+[#47]: https://github.com/intel/fpga-runtime-for-opencl/pull/47
+[#49]: https://github.com/intel/fpga-runtime-for-opencl/pull/49
+[#53]: https://github.com/intel/fpga-runtime-for-opencl/pull/53
+[#60]: https://github.com/intel/fpga-runtime-for-opencl/pull/60
+[#70]: https://github.com/intel/fpga-runtime-for-opencl/pull/70
+[#72]: https://github.com/intel/fpga-runtime-for-opencl/pull/72
+[#73]: https://github.com/intel/fpga-runtime-for-opencl/pull/73
+[#96]: https://github.com/intel/fpga-runtime-for-opencl/pull/96
 
 ## [2022.1] - 2021-12-01
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ runtime repository and submits changes using [pull requests]. Contributions
 must pass continuous integration checks and review by the runtime maintainers
 before they are merged into the `main` branch of the [runtime repository].
 
+## Setting up your Git environment
+
+When using a machine or account for the first time, set your local [git
+identity] including your name and email address for your commits.
+
 ## Setting up your local repository
 
 Using the following steps, you will create a local repository that references
@@ -155,6 +160,7 @@ ability to format a specific commit or only staged files.
 [clang-format]: https://clang.llvm.org/docs/ClangFormat.html
 [create a forked repository]: https://docs.github.com/en/get-started/quickstart/fork-a-repo#forking-a-repository
 [fork and pull model]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/getting-started/about-collaborative-development-models#fork-and-pull-model
+[git identity]: https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup#_your_identity
 [git worktree]: https://git-scm.com/docs/git-worktree
 [git-clang-format]: https://github.com/llvm/llvm-project/blob/9e634b35ff51d0eb2b38013111491e88bdbae388/clang/tools/clang-format/git-clang-format
 [pull requests]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Linux
 
--   Red Hat Enterprise Linux (RHEL)\* or CentOS\* 8
+-   Red Hat Enterprise Linux (RHEL)\* or Rocky Linux\* 8
 -   SUSE Linux Enterprise Server (SLES)\* or openSUSE Leap\* 15
 -   Ubuntu\* 18.04 or 20.04 LTS
 -   GCC 7.4.0 and higher
@@ -134,7 +134,7 @@ ctest -V
 -   On Linux, `aoc` requires the `libtinfo.so.5` library, which you can install
     using one of the following OS-specific commands:
 
-    -   Red Hat Enterprise Linux (RHEL)\* or CentOS\* 8:
+    -   Red Hat Enterprise Linux (RHEL)\* or Rocky Linux\* 8:
 
         ```
         sudo yum install ncurses-compat-libs-6.1

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Perform these steps to build the runtime:
 2.  Switch to the [latest release](https://github.com/intel/fpga-runtime-for-opencl/releases) version.
 
     ```
-    git checkout v2022.1
+    git checkout v2022.2
     ```
 
 3.  Create and change to the runtime build directory.

--- a/container/rockylinux-8-dev/Dockerfile
+++ b/container/rockylinux-8-dev/Dockerfile
@@ -3,7 +3,7 @@
 
 # https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
 
-FROM centos:8
+FROM rockylinux:8
 
 WORKDIR /work
 
@@ -11,8 +11,9 @@ WORKDIR /work
 # to extend the `paths` on which the workflow runs.
 COPY scripts/. ./
 
-RUN sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo \
-  && grep '^enabled=1$' /etc/yum.repos.d/CentOS-Linux-PowerTools.repo \
+RUN \
+  sed -i '/^enabled=/s#0#1#' /etc/yum.repos.d/Rocky-PowerTools.repo \
+  && grep '^enabled=1$' /etc/yum.repos.d/Rocky-PowerTools.repo \
   && yum -y upgrade \
   && yum -y install \
   cmake \

--- a/include/acl_auto.h
+++ b/include/acl_auto.h
@@ -16,9 +16,9 @@ extern "C" {
  * The last one is for the driver version query.  The OpenCL spec says it
  * has to match \d+.\d+ and nothing else.
  */
-#define ACL_VERSION "v2022.1.0"
-#define ACL_VERSION_PLAIN "2022.1"
-#define ACL_VERSION_PLAIN_FOR_DRIVER_QUERY "2022.1"
+#define ACL_VERSION "v2022.2.0"
+#define ACL_VERSION_PLAIN "2022.2"
+#define ACL_VERSION_PLAIN_FOR_DRIVER_QUERY "2022.2"
 
 /* Check if we are currently compiling for ACDS Pro or Standard.
  * 1 means Pro and 0 means Standard.

--- a/scripts/install_zlib.ps1
+++ b/scripts/install_zlib.ps1
@@ -9,7 +9,7 @@ Param(
   $version="1.2.11",
   $builddir="zlib-$version",
   $archive="zlib-$version.tar.gz",
-  $archive_url="https://zlib.net/$archive",
+  $archive_url="https://zlib.net/fossils/$archive",
   $sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 )
 

--- a/scripts/install_zlib.ps1
+++ b/scripts/install_zlib.ps1
@@ -6,11 +6,11 @@
 
 Param(
   [Parameter(Mandatory)]$installdir,
-  $version="1.2.11",
+  $version="1.2.12",
   $builddir="zlib-$version",
   $archive="zlib-$version.tar.gz",
   $archive_url="https://zlib.net/fossils/$archive",
-  $sha256="c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+  $sha256="91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
 )
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
This backports small documentation and infrastructure changes to 2022.2. ~~Note how the list of workflow runs does **not** include Klocwork since build and source files are unchanged, as should be the case post code complete.~~ The list of workflow runs does include Klocwork due to [updating acl_auto.h for the 2022.2 release](https://github.com/intel/fpga-runtime-for-opencl/pull/98/commits/cf1412566db48b0bfd0eb0346b80f0371f55e158). :facepalm: