### PR TITLE
[Device Global] Autodiscovery change

### DIFF
--- a/include/acl.h
+++ b/include/acl.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <assert.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <CL/cl_ext.h>
@@ -478,6 +479,12 @@ typedef class acl_device_program_info_t *acl_device_program_info;
  */
 #define ACL_MEM_CAPABILITY_P2P (1 << 3)
 
+// Definition of device global.
+struct acl_device_global_mem_def_t {
+  uint32_t address;
+  uint32_t size;
+};
+
 // Part of acl_device_def_t where members are populated from the information
 // in the autodiscovery string. This will get updated every time the device
 // is programmed with a new device binary as the new binary would contain a
@@ -496,6 +503,10 @@ typedef struct acl_device_def_autodiscovery_t {
   std::array<acl_system_global_mem_def_t, ACL_MAX_GLOBAL_MEM> global_mem_defs;
 
   std::vector<acl_hostpipe_info_t> acl_hostpipe_info;
+
+  // Device global definition.
+  std::unordered_map<std::string, acl_device_global_mem_def_t>
+      device_global_mem_defs;
 } acl_device_def_autodiscovery_t;
 
 typedef struct acl_device_def_t {


### PR DESCRIPTION
Autodiscovery help bridge the communication between backend and runtime.

The autodiscovery will contain the following information for a device global:
1. device global name
2. device global address
3. device global size

The autodiscovery will be in the following format:
`<number of device global> <number of field in each device global> [(<name>, <address>, <size>), (...), ...]`

The autodiscovery change came from https://github.com/intel/fpga-runtime-for-opencl/pull/65