### PR TITLE
Initialize max number of global memory definition for simulator

### DIFF
--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -4424,19 +4424,6 @@ void acl_resize_reserved_allocations_for_device(cl_mem mem,
   unsigned int num_global_mem_systems =
       def.autodiscovery_def.num_global_mem_systems;
 
-  // When we don't know how many memory systems will exist
-  // Load as much as needed.
-  num_global_mem_systems = std::max(num_global_mem_systems, mem->mem_id + 1);
-
-  // For the simulation flow we don't know how many memory systems will exist
-  // until we load the .aocx, which may not happen until somewhat later.
-  // Reserving space is quite cheap, so reserve space for many memory systems.
-  int offline_mode = 0;
-  (void)acl_get_offline_device_user_setting(&offline_mode);
-  if (offline_mode == ACL_CONTEXT_MPSIM) {
-    num_global_mem_systems = std::max(num_global_mem_systems, 128u);
-  }
-
 #ifdef MEM_DEBUG_MSG
   printf(
       "resizing reserved_allocations, physical_device_id:%u, target_size:%u \n",


### PR DESCRIPTION
Simulator does not have any global memory interface information until the actuall aocx is loaded.
(Note this is only a problem for simulator not hardware run, in hardware run, we can communicate with BSP to query memory interface information)
Prior to loading aocx it uses predefined autodiscovery [1] to initialize its global memory interface, which has only 1 global memory
In the sycl runtime flow today, the USM device allocation call happens before aocx is loaded.
The aocx is loaded when clCreateProgram is called, which typically happen on first kernel launch in sycl runtime.
The USM device allocation on mutli global memory system will fail because there are in total 1 global memory as defined in [1] but the user is requesting more than 1 device global memory.
User could go around this issue by launching a sacrificial kernel that uses shared allocation as kernel argument. This will setup the correct global memory interface in runtime.
This change eliminate the need to run a sacrificial kernel.
However there are a few downside:
1. The address range/size may not be exactly the same as the one that is in aocx, but this is not too large of a problem because runtime first fit allocation algorithm will fill the lowest address range first. Unless user requested more than what is availble.
2. it potentially occupied more space than required
3. will not error out when user requested a non-existing device global memory because we are using ACL_MAX_GLOBAL_MEM for num_global_mem_systems

[1] https://github.com/intel/fpga-runtime-for-opencl/blob/950f21dd079dfd55a473ba4122a4a9dca450e36f/include/acl_shipped_board_cfgs.h#L7