### PR TITLE
Override uid of default user in container to align with GitHub-hosted runners

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -82,8 +82,10 @@ jobs:
         env:
           ref: ${{ github.ref }}
 
+      # Override uid of default user in container to align with GitHub-hosted runners
+      # https://github.com/actions/checkout/issues/47
       - name: build image
-        run: docker build -t "$image:$tag" -f container/${{ matrix.container }}/Dockerfile .
+        run: docker build --build-arg uid=1001 -t "$image:$tag" -f container/${{ matrix.container }}/Dockerfile .
         env:
           tag: ${{ steps.tag.outputs.tag }}
 

--- a/container/debian-11-arm-dev/Dockerfile
+++ b/container/debian-11-arm-dev/Dockerfile
@@ -5,6 +5,10 @@
 
 FROM debian:11
 
+# Optionally override uid of default user in container, e.g.,
+# docker build --build-arg uid=1001 ...
+ARG uid
+
 WORKDIR /work
 
 # Before using a new script, update .github/workflows/container.yml
@@ -32,7 +36,7 @@ RUN dpkg --add-architecture armhf \
   libelf-dev:armhf \
   zlib1g-dev:armhf \
   && apt-get -y clean \
-  && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
+  && useradd --system ${uid:+--uid "$uid"} --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
   && rm -rf "$PWD"
 

--- a/container/opensuse-leap-15-dev/Dockerfile
+++ b/container/opensuse-leap-15-dev/Dockerfile
@@ -5,6 +5,10 @@
 
 FROM opensuse/leap:15
 
+# Optionally override uid of default user in container, e.g.,
+# docker build --build-arg uid=1001 ...
+ARG uid
+
 WORKDIR /work
 
 # Before using a new script, update .github/workflows/container.yml
@@ -32,7 +36,7 @@ RUN zypper -n update \
   zlib-devel \
   && zypper -n clean \
   && ./install_aocl.sh /opt/aocl \
-  && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
+  && useradd --system ${uid:+--uid "$uid"} --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
   && rm -rf "$PWD"
 

--- a/container/rockylinux-8-dev/Dockerfile
+++ b/container/rockylinux-8-dev/Dockerfile
@@ -5,6 +5,10 @@
 
 FROM rockylinux:8
 
+# Optionally override uid of default user in container, e.g.,
+# docker build --build-arg uid=1001 ...
+ARG uid
+
 WORKDIR /work
 
 # Before using a new script, update .github/workflows/container.yml
@@ -38,7 +42,7 @@ RUN \
   zlib-devel \
   && yum -y clean all \
   && ./install_aocl.sh /opt/aocl \
-  && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
+  && useradd --system ${uid:+--uid "$uid"} --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
   && rm -rf "$PWD"
 

--- a/container/ubuntu-18.04-dev/Dockerfile
+++ b/container/ubuntu-18.04-dev/Dockerfile
@@ -5,6 +5,10 @@
 
 FROM ubuntu:18.04
 
+# Optionally override uid of default user in container, e.g.,
+# docker build --build-arg uid=1001 ...
+ARG uid
+
 WORKDIR /work
 
 # Before using a new script, update .github/workflows/container.yml
@@ -41,7 +45,7 @@ RUN apt-get -y update \
   zlib1g-dev \
   && apt-get -y clean \
   && ./install_aocl.sh /opt/aocl \
-  && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
+  && useradd --system ${uid:+--uid "$uid"} --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
   && rm -rf "$PWD"
 

--- a/container/ubuntu-20.04-clang/Dockerfile
+++ b/container/ubuntu-20.04-clang/Dockerfile
@@ -12,6 +12,10 @@ ARG clang_archive_sig=$clang_archive.sig
 ARG clang_archive_url=https://github.com/llvm/llvm-project/releases/download/llvmorg-$clang_version/$clang_archive
 ARG clang_archive_sig_url=$clang_archive_url.sig
 
+# Optionally override uid of default user in container, e.g.,
+# docker build --build-arg uid=1001 ...
+ARG uid
+
 WORKDIR /work
 
 # https://releases.llvm.org/download.html
@@ -33,7 +37,7 @@ RUN apt-get -y update \
   && tar --strip-components=1 -C "$clang_installdir" -xf "$clang_archive" \
   && chown -R root:root "$clang_installdir" \
   && chmod -R u=rwX,g=rX,o=rX "$clang_installdir" \
-  && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
+  && useradd --system ${uid:+--uid "$uid"} --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
   && rm -rf "$PWD"
 

--- a/container/ubuntu-20.04-dev/Dockerfile
+++ b/container/ubuntu-20.04-dev/Dockerfile
@@ -5,6 +5,10 @@
 
 FROM ubuntu:20.04
 
+# Optionally override uid of default user in container, e.g.,
+# docker build --build-arg uid=1001 ...
+ARG uid
+
 WORKDIR /work
 
 # Before using a new script, update .github/workflows/container.yml
@@ -28,7 +32,7 @@ RUN apt-get -y update \
   zlib1g-dev \
   && apt-get -y clean \
   && ./install_aocl.sh /opt/aocl \
-  && useradd --system --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
+  && useradd --system ${uid:+--uid "$uid"} --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
   && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
   && rm -rf "$PWD"
 


### PR DESCRIPTION
This resolves a recent regression with GitHub-hosted runners where
actions/checkout@v2 fails to create a directory under /__w/_temp/
    
https://github.com/intel/fpga-runtime-for-opencl/pull/104#issuecomment-1099590565
    
https://github.com/actions/checkout/issues/47