### PR TITLE
Fix build failure with macro MEM_DEBUG_MSG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,6 +303,7 @@ target_compile_definitions(acl_objs PUBLIC
   CL_USE_DEPRECATED_OPENCL_1_1_APIS=1
   CL_USE_DEPRECATED_OPENCL_1_2_APIS=1
   CL_TARGET_OPENCL_VERSION=300
+  $<$<CONFIG:Debug>:MEM_DEBUG_MSG>
   )
 target_include_directories(acl_objs PUBLIC include)
 target_include_directories(acl_objs PRIVATE

--- a/src/acl_kernel.cpp
+++ b/src/acl_kernel.cpp
@@ -2848,7 +2848,9 @@ l_copy_and_adjust_arguments_for_device(cl_kernel kernel, cl_device_id device,
 #ifdef MEM_DEBUG_MSG
         printf("regular buffer ");
 #endif
-        unsigned needed_mem_id = l_get_kernel_arg_mem_id(kernel, iarg);
+        const unsigned int needed_mem_id =
+            l_get_kernel_arg_mem_id(kernel, iarg);
+        const unsigned int needed_physical_id = device->def.physical_device_id;
 
 // Always enqueue a migration, even if the memory is where it should be there
 // could be something in the queue ahead of us which will move the memory.
@@ -2858,7 +2860,6 @@ l_copy_and_adjust_arguments_for_device(cl_kernel kernel, cl_device_id device,
 #endif
 
         // first, is there a reserved region?
-        unsigned needed_physical_id = device->def.physical_device_id;
         if (mem_obj->reserved_allocations_count[needed_physical_id].size() ==
             0) {
           acl_resize_reserved_allocations_for_device(mem_obj, device->def);

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -4467,13 +4467,14 @@ cl_int acl_reserve_buffer_block(cl_mem mem, acl_mem_region_t *region,
     result = copy_image_metadata(mem);
   }
 
-  if (result) {
-    mem->reserved_allocations[physical_device_id][target_mem_id] =
-        block_allocation;
-    block_allocation->mem_obj = mem;
-  } else {
+  if (!result) {
     acl_delete(block_allocation);
+    return result;
   }
+
+  mem->reserved_allocations[physical_device_id][target_mem_id] =
+      block_allocation;
+  block_allocation->mem_obj = mem;
 
 #ifdef MEM_DEBUG_MSG
   printf("acl_reserve_buffer_block finished block_allocation:%zx, range:%zx - "


### PR DESCRIPTION
Found this as part of debugging for implementing #103:
```
../../src/acl_kernel.cpp:2856:59: error: ‘needed_physical_id’ was not declared in this scope
         printf("needed_physical_id %d needed_mem_id %d ", needed_physical_id,
                                                           ^~~~~~~~~~~~~~~~~~
```