### PR TITLE
Factor out functions for auto-discovery parsing

### DIFF
--- a/src/acl_auto_configure.cpp
+++ b/src/acl_auto_configure.cpp
@@ -548,8 +548,9 @@ static bool read_kernel_args(const std::string &config_str,
                                                 buffer_location, counters);
       }
       if (result && num_buffer_locations > 1) {
-        std::cerr << "WARNING: kernel argument has multiple buffer_location "
-                     "attributes which is not supported.\nSelecting "
+        std::cerr << "WARNING: kernel argument " << j
+                  << " has multiple buffer_location attributes which is not "
+                     "supported.\nSelecting "
                   << buffer_location << " as buffer location.\n";
       }
     }


### PR DESCRIPTION
This factors out parsing of auto-discovery string sections into separate functions to improve the readability and maintenance of `acl_load_device_def_from_str()`. Care was taken not to modify the functional behaviour, by carrying out the refactoring twice and ensuring that the results are identical.

A choice had to be made between factoring out parsing of individual section entries, e.g., a single kernel argument, versus factoring out entire loops, e.g., all kernel arguments. The latter was chosen since the data structures vary (`vector` versus `unordered_map`), and, importantly, the number of fields vary between variable and fixed counts. For [variable count](https://github.com/intel/fpga-runtime-for-opencl/blob/a446b30c59e3c0b45eeeb0a1897dbbddc9bd9e9e/src/acl_auto_configure.cpp#L695-L700), the number of fields is read for each entry; whereas for [fixed count](https://github.com/intel/fpga-runtime-for-opencl/blob/a446b30c59e3c0b45eeeb0a1897dbbddc9bd9e9e/src/acl_auto_configure.cpp#L454-L462), the number of fields is read once for all entries. By factoring out the entire loop, the field count parsing is contained within the function in both cases.