### PR TITLE
Print warning when kernel argument has multiple buffer_location attributes

### DIFF
--- a/src/acl_auto_configure.cpp
+++ b/src/acl_auto_configure.cpp
@@ -685,7 +685,6 @@ bool acl_load_device_def_from_str(const std::string &config_str,
         auto addr_space_type = 0U;
         auto category = 0U;
         auto size = 0U;
-        auto num_buffer_locations = 0U;
         int total_fields_arguments = 0;
         if (result) {
           result =
@@ -706,15 +705,18 @@ bool acl_load_device_def_from_str(const std::string &config_str,
 
         std::string buffer_location = "";
         if (result) {
+          unsigned int num_buffer_locations = 0;
           result = result && read_uint_counters(config_str, curr_pos,
                                                 num_buffer_locations, counters);
-          for (auto k = 0U; result && (k < num_buffer_locations); k++) {
-            if (j > 0) {
-              buffer_location = buffer_location + " ";
-            }
-
+          for (unsigned int k = 0; result && (k < num_buffer_locations); k++) {
             result = result && read_string_counters(config_str, curr_pos,
                                                     buffer_location, counters);
+          }
+          if (result && num_buffer_locations > 1) {
+            std::cerr
+                << "WARNING: kernel argument has multiple buffer_location "
+                   "attributes which is not supported.\nSelecting "
+                << buffer_location << " as buffer location.\n";
           }
         }
 


### PR DESCRIPTION
The auto-discovery string parsing of per kernel argument buffer_location
intended to concatenate multiple attributes into a space-separated string,
but in fact only retains the value of the last buffer_location attribute
since read_string_counters() does not append but assign the string value.

Since multiple buffer_location attributes are not supported, print a
warning message, and select the last buffer_location attribute such that
the functional behaviour of buffer_location parsing remains unchanged.

This is a prerequisite of #108 and #103, since the current implementation
incorrectly checks argument index `j` instead of attribute index `k` which
results in a build failure when factoring out kernel argument parsing into
a separate function.