### PR TITLE
cmake: consistently enable verbose output for all tests

### DIFF
--- a/lib/acl_check_sys_cmd/test/CMakeLists.txt
+++ b/lib/acl_check_sys_cmd/test/CMakeLists.txt
@@ -3,4 +3,4 @@
 
 add_executable(acl_check_sys_cmd_test acl_check_sys_cmd_test.cpp)
 target_link_libraries(acl_check_sys_cmd_test PRIVATE acl_check_sys_cmd)
-add_test(acl_check_sys_cmd_test acl_check_sys_cmd_test)
+add_test(acl_check_sys_cmd_test acl_check_sys_cmd_test -v)

--- a/lib/acl_hash/test/CMakeLists.txt
+++ b/lib/acl_hash/test/CMakeLists.txt
@@ -6,4 +6,4 @@ target_link_libraries(acl_hash_test PRIVATE acl_hash CppUTest)
 target_compile_definitions(acl_hash_test PRIVATE
   "ACL_TARGET_BIT=${ACL_TARGET_BIT}"
 )
-add_test(acl_hash_test acl_hash_test)
+add_test(acl_hash_test acl_hash_test -v)

--- a/lib/acl_threadsupport/test/CMakeLists.txt
+++ b/lib/acl_threadsupport/test/CMakeLists.txt
@@ -6,4 +6,4 @@ target_link_libraries(acl_threadsupport_test PRIVATE acl_threadsupport CppUTest)
 target_compile_definitions(acl_threadsupport_test PRIVATE
   "ACL_TARGET_BIT=${ACL_TARGET_BIT}"
   )
-add_test(acl_threadsupport_test acl_threadsupport_test)
+add_test(acl_threadsupport_test acl_threadsupport_test -v)

--- a/lib/pkg_editor/test/CMakeLists.txt
+++ b/lib/pkg_editor/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 add_executable(pkg_editor_test pkg_editor_test.cpp)
 target_link_libraries(pkg_editor_test PRIVATE CppUTest pkg_editor)
-add_test(pkg_editor_test pkg_editor_test)
+add_test(pkg_editor_test pkg_editor_test -v)
 
 if(ZLIB_FOUND)
   target_compile_definitions(pkg_editor_test PRIVATE USE_ZLIB)


### PR DESCRIPTION
Found while collecting address sanitizer issues in https://github.com/intel/fpga-runtime-for-opencl/pull/118