### PR TITLE
First set of run-time scalability improvements to scale gracefully to…

### DIFF
--- a/include/acl_hal.h
+++ b/include/acl_hal.h
@@ -57,12 +57,12 @@ struct acl_pkg_file;
 /// @name Callback type declarations
 ///@{
 typedef void (*acl_event_update_callback)(cl_event event, int new_status);
-typedef void (*acl_kernel_update_callback)(int activation_id, cl_int status);
-typedef void (*acl_profile_callback)(int activation_id);
+typedef void (*acl_kernel_update_callback)(unsigned int physical_device_id, int activation_id, cl_int status);
+typedef void (*acl_profile_callback)(unsigned int physical_device_id, int activation_id);
 typedef void (*acl_device_update_callback)(
     unsigned physical_device_id, CL_EXCEPTION_TYPE_INTEL exception_type,
     void *user_private_info, size_t user_cb);
-typedef void (*acl_process_printf_buffer_callback)(int activation_id, int size,
+typedef void (*acl_process_printf_buffer_callback)(unsigned int physical_device_id, int activation_id, int size,
                                                    int debug_dump_printf);
 ///@}
 

--- a/include/acl_kernel.h
+++ b/include/acl_kernel.h
@@ -41,12 +41,12 @@ void acl_launch_kernel(void *user_data, acl_device_op_t *op);
 
 // Called when we get a kernel interrupt indicating that profiling data is ready
 ACL_EXPORT
-void acl_profile_update(int activation_id);
+void acl_profile_update(unsigned int physical_device_id, int activation_id);
 
 // This should be called by the HAL, to receive notification of RUNNING and
 // COMPLETE state transitions, and used printf buffer size
 ACL_EXPORT
-void acl_receive_kernel_update(int activation_id, cl_int status);
+void acl_receive_kernel_update(unsigned int physical_device_id, int activation_id, cl_int status);
 
 // Used to check if one of the kernel arguments needs to be mapped to the device
 // When unmapping subbuffers we may transfer memory that is currently used

--- a/include/acl_platform.h
+++ b/include/acl_platform.h
@@ -22,6 +22,11 @@ void acl_init_platform(void);
 void acl_finalize_init_platform(unsigned int num_devices,
                                 const cl_device_id *devices);
 const char *acl_platform_extensions(void);
+acl_device_op_queue_t *get_device_op_queue(unsigned int physical_device_id);
+acl_device_op_queue_t *get_device_op_queue_from_context(cl_context context);
+
+acl_locking_data_t *get_device_op_queue_locking_data(cl_device_id device);
+acl_locking_data_t *get_device_op_queue_locking_data_from_context(cl_context context);
 
 #if defined(__cplusplus)
 } /* extern "C" */

--- a/include/acl_printf.h
+++ b/include/acl_printf.h
@@ -18,7 +18,7 @@ extern "C" {
 
 // Enqueue printf buffer dump
 ACL_EXPORT
-void acl_schedule_printf_buffer_pickup(int activation_id, int size,
+void acl_schedule_printf_buffer_pickup(unsigned int physical_device_id, int activation_id, int size,
                                        int overflow);
 
 // Print the printf data associated with the given deviced operation

--- a/src/acl_command_queue.cpp
+++ b/src/acl_command_queue.cpp
@@ -625,7 +625,7 @@ int acl_update_queue(cl_command_queue command_queue) {
   }
 
   // First nudge the device operation scheduler.
-  acl_update_device_op_queue(&(acl_platform.device_op_queue));
+  acl_update_device_op_queue(get_device_op_queue_from_context(command_queue->context));
 
   if (command_queue->properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) {
     return acl_update_ooo_queue(command_queue);

--- a/src/acl_hal_mmd.cpp
+++ b/src/acl_hal_mmd.cpp
@@ -2632,7 +2632,8 @@ void acl_hal_mmd_reset_kernels(cl_device_id device) {
       int activation_id = kern[physical_device_id].accel_job_ids[k][i];
       if (kern[physical_device_id].accel_job_ids[k][i] >= 0) {
         kern[physical_device_id].accel_job_ids[k][i] = -1;
-        acl_kernel_update_fn(activation_id,
+        acl_kernel_update_fn(physical_device_id,
+                             activation_id,
                              -1); // Signal that it finished with error, since
                                   // we forced it to finish
       }

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -1250,7 +1250,7 @@ void acl_kernel_if_launch_kernel_on_custom_sof(
   // next to launch, its status will be set to CL_RUNNING and below call
   // to update status will do nothing
   if (kern->accel_queue_front[accel_id] == kern->accel_queue_back[accel_id]) {
-    acl_kernel_if_update_fn((int)(activation_id), CL_RUNNING);
+    acl_kernel_if_update_fn(kern->physical_device_id, (int)(activation_id), CL_RUNNING);
   }
   kern->accel_queue_front[accel_id] = next_launch_index;
 
@@ -1394,7 +1394,7 @@ void acl_kernel_if_update_status(acl_kernel_if *kern) {
                                 activation_id, printf_size);
         // update status, which will dump the printf buffer, set
         // debug_dump_printf = 0
-        acl_process_printf_buffer_fn(activation_id, (int)printf_size, 0);
+        acl_process_printf_buffer_fn(kern->physical_device_id, activation_id, (int)printf_size, 0);
 
         ACL_KERNEL_IF_DEBUG_MSG(
             kern, ":: Accelerator %d new csr is %x.\n", k,
@@ -1432,7 +1432,7 @@ void acl_kernel_if_update_status(acl_kernel_if *kern) {
         // This is an autorun kernel
         acl_process_autorun_profiler_scan_chain(kern->physical_device_id, k);
       } else {
-        acl_kernel_profile_fn(activation_id);
+        acl_kernel_profile_fn(kern->physical_device_id, activation_id);
       }
       continue;
     }
@@ -1482,7 +1482,7 @@ void acl_kernel_if_update_status(acl_kernel_if *kern) {
                                 ":: Calling acl_process_printf_buffer_fn with "
                                 "activation_id=%d and printf_size=%u.\n",
                                 activation_id, printf_size);
-        acl_process_printf_buffer_fn(activation_id, (int)printf_size, 0);
+        acl_process_printf_buffer_fn(kern->physical_device_id, activation_id, (int)printf_size, 0);
       }
 
       // Executing the following update after reading from performance
@@ -1491,7 +1491,7 @@ void acl_kernel_if_update_status(acl_kernel_if *kern) {
       // completion timestamp - reading performance results through slave
       // ports before setting CL_COMPLETE adds to the apparent kernel time.
       //
-      acl_kernel_if_update_fn(activation_id, CL_COMPLETE);
+      acl_kernel_if_update_fn(kern->physical_device_id, activation_id, CL_COMPLETE);
       kern->accel_queue_back[k] = next_queue_back;
 
       if (kern->accel_queue_back[k] ==
@@ -1501,7 +1501,8 @@ void acl_kernel_if_update_status(acl_kernel_if *kern) {
         next_queue_back = kern->accel_queue_back[k] + 1;
 
       if (kern->accel_job_ids[k][next_queue_back] > -1) {
-        acl_kernel_if_update_fn(kern->accel_job_ids[k][next_queue_back],
+        acl_kernel_if_update_fn(kern->physical_device_id,
+                                kern->accel_job_ids[k][next_queue_back],
                                 CL_RUNNING);
       }
     }
@@ -1542,7 +1543,7 @@ void acl_kernel_if_debug_dump_printf(acl_kernel_if *kern, unsigned k) {
                             activation_id, printf_size);
 
     // set debug_dump_printf to 1
-    acl_process_printf_buffer_fn(activation_id, (int)printf_size, 1);
+    acl_process_printf_buffer_fn(kern->physical_device_id, activation_id, (int)printf_size, 1);
   }
 }
 

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -5312,7 +5312,7 @@ int acl_submit_mem_transfer_device_op(cl_event event) {
     return result;
   }
 
-  acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+  acl_device_op_queue_t *doq = get_device_op_queue_from_context(event->context);
   acl_device_op_t *last_op = 0;
   int src_on_host;
   int dst_on_host;
@@ -7045,7 +7045,7 @@ int acl_submit_migrate_mem_device_op(cl_event event) {
     unsigned int ibuf;
     int ok = 1;
     acl_mem_migrate_t memory_migration = event->cmd.info.memory_migration;
-    acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+    acl_device_op_queue_t *doq = get_device_op_queue_from_context(event->context);
     acl_device_op_t *last_op = 0;
 
     // Precautionary, but it also nudges the device scheduler to try

--- a/src/acl_offline_hal.cpp
+++ b/src/acl_offline_hal.cpp
@@ -269,10 +269,9 @@ static void acl_offline_hal_launch_kernel(
   cl_int activation_id = invocation_wrapper->image->activation_id;
   acl_assert_locked();
 
-  physical_id = physical_id;
   // For emulating an offline device, just say we start and finish right away.
-  acl_offline_hal_kernel_callback(activation_id, CL_RUNNING);
-  acl_offline_hal_kernel_callback(activation_id, CL_COMPLETE);
+  acl_offline_hal_kernel_callback(physical_id, activation_id, CL_RUNNING);
+  acl_offline_hal_kernel_callback(physical_id, activation_id, CL_COMPLETE);
 }
 
 static void acl_offline_hal_unstall_kernel(unsigned int physical_id,

--- a/src/acl_printf.cpp
+++ b/src/acl_printf.cpp
@@ -28,6 +28,7 @@
 #include <acl_event.h>
 #include <acl_globals.h>
 #include <acl_kernel.h>
+#include <acl_platform.h>
 #include <acl_printf.h>
 #include <acl_program.h>
 #include <acl_svm.h>
@@ -987,9 +988,9 @@ static size_t l_dump_printf_buffer(cl_event event, cl_kernel kernel,
 //
 // Schedule enqueue read buffer to read printf buffer
 // The activation ID is the device op ID.
-void acl_schedule_printf_buffer_pickup(int activation_id, int size,
+void acl_schedule_printf_buffer_pickup(unsigned int physical_device_id, int activation_id, int size,
                                        int debug_dump_printf) {
-  acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+  acl_device_op_queue_t *doq = get_device_op_queue(physical_device_id);
 
   // This function can potentially be called by a HAL that does not use the
   // ACL global lock, so we need to use acl_lock() instead of

--- a/src/acl_program.cpp
+++ b/src/acl_program.cpp
@@ -26,6 +26,7 @@
 #include <acl_hostch.h>
 #include <acl_icd_dispatch.h>
 #include <acl_mem.h>
+#include <acl_platform.h>
 #include <acl_program.h>
 #include <acl_support.h>
 #include <acl_thread.h>
@@ -2035,7 +2036,7 @@ int acl_submit_program_device_op(cl_event event) {
     return result;
   }
   if (!event->last_device_op) {
-    acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+    acl_device_op_queue_t *doq = get_device_op_queue_from_context(event->context);
     acl_device_op_t *last_op = 0;
 
     // Precautionary, but it also nudges the device scheduler to try

--- a/src/acl_usm.cpp
+++ b/src/acl_usm.cpp
@@ -1071,7 +1071,7 @@ int acl_submit_usm_memcpy(cl_event event) {
     return result;
   }
 
-  acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+  acl_device_op_queue_t *doq = get_device_op_queue_from_context(event->context);
   acl_device_op_t *last_op = 0;
 
   // Precautionary, but it also nudges the device scheduler to try

--- a/test/acl_command_queue_test.cpp
+++ b/test/acl_command_queue_test.cpp
@@ -730,9 +730,9 @@ MT_TEST(acl_command_queue, mixed_queue_dependencies_1) {
 
   // Finish e1, see if e2 gets submitted
   CHECK_EQUAL(e1->last_device_op, e1->current_device_op);
-  ACL_LOCKED(acl_receive_kernel_update(e1->current_device_op->id, CL_RUNNING));
+  ACL_LOCKED(acl_receive_kernel_update(m_device[0]->def.physical_device_id, e1->current_device_op->id, CL_RUNNING));
   ACL_LOCKED(acl_idle_update(context));
-  ACL_LOCKED(acl_receive_kernel_update(e1->current_device_op->id, CL_COMPLETE));
+  ACL_LOCKED(acl_receive_kernel_update(m_device[0]->def.physical_device_id, e1->current_device_op->id, CL_COMPLETE));
   ACL_LOCKED(acl_idle_update(context));
 
   CHECK_EQUAL(CL_COMPLETE, e2->execution_status); // The important check
@@ -806,9 +806,9 @@ MT_TEST(acl_command_queue, mixed_queue_dependencies_2) {
 
   // Finish e1, see if e2 gets submitted
   CHECK_EQUAL(e1->last_device_op, e1->current_device_op);
-  ACL_LOCKED(acl_receive_kernel_update(e1->current_device_op->id, CL_RUNNING));
+  ACL_LOCKED(acl_receive_kernel_update(m_device[0]->def.physical_device_id, e1->current_device_op->id, CL_RUNNING));
   ACL_LOCKED(acl_idle_update(context));
-  ACL_LOCKED(acl_receive_kernel_update(e1->current_device_op->id, CL_COMPLETE));
+  ACL_LOCKED(acl_receive_kernel_update(m_device[0]->def.physical_device_id, e1->current_device_op->id, CL_COMPLETE));
   ACL_LOCKED(acl_idle_update(context));
 
   CHECK_EQUAL(CL_COMPLETE, e2->execution_status); // The important check

--- a/test/acl_device_op_test.cpp
+++ b/test/acl_device_op_test.cpp
@@ -16,6 +16,7 @@
 #include <acl_device_op.h>
 #include <acl_event.h>
 #include <acl_globals.h>
+#include <acl_platform.h>
 #include <acl_types.h>
 #include <acl_util.h>
 
@@ -843,7 +844,7 @@ TEST(device_op, prune) {
   cl_event e0 = clCreateUserEvent(m_context, 0);
   CHECK(e0);
 
-  acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+  acl_device_op_queue_t *doq = get_device_op_queue_from_context(m_context);
 
   acl_device_op_t *op0 = acl_propose_device_op(doq, ACL_DEVICE_OP_NONE, e0);
   acl_device_op_t *op1 = acl_propose_device_op(doq, ACL_DEVICE_OP_NONE, e0);

--- a/test/acl_hal_test.cpp
+++ b/test/acl_hal_test.cpp
@@ -463,19 +463,19 @@ void acltest_call_event_update_callback(cl_event event, int new_status) {
   acltest_hal_event_callback(event, new_status);
 }
 
-void acltest_call_kernel_update_callback(int activation_id, cl_int status) {
-  acltest_hal_kernel_callback(activation_id, status);
+void acltest_call_kernel_update_callback(unsigned int physical_device_id, int activation_id, cl_int status) {
+  acltest_hal_kernel_callback(physical_device_id, activation_id, status);
 }
 
-void acltest_call_device_update_callback(unsigned physical_device_id,
+void acltest_call_device_update_callback(unsigned int physical_device_id,
                                          int device_status) {
   acltest_hal_device_callback(physical_device_id,
                               (CL_EXCEPTION_TYPE_INTEL)device_status, NULL, 0);
 }
 
-void acltest_call_printf_buffer_callback(int activation_id, int size,
+void acltest_call_printf_buffer_callback(unsigned int physical_device_id, int activation_id, int size,
                                          int stalled) {
-  acltest_process_printf_buffer_callback(activation_id, size, stalled);
+  acltest_process_printf_buffer_callback(physical_device_id, activation_id, size, stalled);
 }
 
 void acltest_hal_launch_kernel(

--- a/test/acl_hal_test.h
+++ b/test/acl_hal_test.h
@@ -20,8 +20,8 @@ void acl_test_hal_set_physical_memory_support(bool value);
 extern bool acltest_hal_emulate_device_mem;
 
 void acltest_call_event_update_callback(cl_event event, int new_status);
-void acltest_call_kernel_update_callback(int activation_id, cl_int status);
-void acltest_call_printf_buffer_callback(int activation_id, int size,
+void acltest_call_kernel_update_callback(unsigned int physical_device_id, int activation_id, cl_int status);
+void acltest_call_printf_buffer_callback(unsigned int physical_device_id, int activation_id, int size,
                                          int stalled);
 
 #endif

--- a/test/acl_profiler_test.cpp
+++ b/test/acl_profiler_test.cpp
@@ -23,6 +23,7 @@
 #include <acl_event.h>
 #include <acl_globals.h>
 #include <acl_kernel.h>
+#include <acl_platform.h>
 #include <acl_printf.h>
 #include <acl_profiler.h>
 #include <acl_program.h>
@@ -60,11 +61,12 @@ MT_TEST_GROUP(acl_profile) {
       putenv(profiler_timer_env_var);
 #endif
       acl_test_setup_generic_system();
-      acl_dot_push(&m_devlog, &acl_platform.device_op_queue);
 
       this->load();
       m_program = this->load_program();
       this->build(m_program);
+
+      acl_dot_push(&m_devlog, get_device_op_queue_from_context(m_context));
     }
     syncThreads();
   }

--- a/test/acl_test.cpp
+++ b/test/acl_test.cpp
@@ -683,8 +683,8 @@ static void l_run_benchmark() {
 
       int activation_id = kernel_event->cmd.info.ndrange_kernel
                               .invocation_wrapper->image->activation_id;
-      acltest_call_kernel_update_callback(activation_id, CL_RUNNING);
-      acltest_call_kernel_update_callback(activation_id, CL_COMPLETE);
+      acltest_call_kernel_update_callback(device->def.physical_device_id, activation_id, CL_RUNNING);
+      acltest_call_kernel_update_callback(device->def.physical_device_id, activation_id, CL_COMPLETE);
 
       status = clWaitForEvents(1, &kernel_event);
       assert(status == CL_SUCCESS);

--- a/test/acl_thread_test.cpp
+++ b/test/acl_thread_test.cpp
@@ -205,7 +205,7 @@ MT_TEST(acl_thread, kernel_and_printf_callback) {
 
   if (threadNum() < (int)device_def->accel.size()) {
     // signal kernel is running
-    acltest_call_kernel_update_callback(activation_id, CL_RUNNING);
+    acltest_call_kernel_update_callback(sys_def->device[0].physical_device_id, activation_id, CL_RUNNING);
 
     // wait for kernel status to change
     cl_int execution_status = CL_QUEUED;
@@ -220,7 +220,7 @@ MT_TEST(acl_thread, kernel_and_printf_callback) {
 
   if (threadNum() < (int)device_def->accel.size()) {
     // signal kernel has printf buffer
-    acltest_call_printf_buffer_callback(activation_id, 100, 0);
+    acltest_call_printf_buffer_callback(sys_def->device[0].physical_device_id, activation_id, 100, 0);
 
     // wait for printf buffer to be cleared
     CHECK(kernel_event);
@@ -237,7 +237,7 @@ MT_TEST(acl_thread, kernel_and_printf_callback) {
 
   if (threadNum() < (int)device_def->accel.size()) {
     // signal kernel is finished
-    acltest_call_kernel_update_callback(activation_id, CL_COMPLETE);
+    acltest_call_kernel_update_callback(sys_def->device[0].physical_device_id, activation_id, CL_COMPLETE);
 
     status = clWaitForEvents(1, &kernel_event);
     CHECK_EQUAL(CL_SUCCESS, status);


### PR DESCRIPTION
… 8 and more FPGAs per single host program.

- Have separate device operation queue for contexts with non-overlapping device sets.
- Each dev op queue has its own set of locking data (but not used yet). With following changes, will switch to using per-dev op queue locks for most opeations. This version of the code still uses a single global lock.
- TODO: dev op queue is dynamically allocated but not freed. Only a problem if user creates and releases contexts often.
-       Creating a new context with devices used by existing contexts may cause an existing context to be re-assigned to a different device op queue. This currently happens without waiting for the original dev op queue to drain. Again, a corner case we shouldn't hit in normal host programs.