### PR TITLE
Address integer conversion warnings in CppUTest

### DIFF
--- a/lib/CppUTest/include/CppUTest/Failure.h
+++ b/lib/CppUTest/include/CppUTest/Failure.h
@@ -56,7 +56,7 @@ public:
 
 	virtual SimpleString getFileName() const;
 	virtual SimpleString getTestName() const;
-	virtual int getLineNumber() const;
+	virtual long getLineNumber() const;
 	virtual SimpleString getMessage() const;
 
 protected:

--- a/lib/CppUTest/include/CppUTest/MemoryLeakDetector.h
+++ b/lib/CppUTest/include/CppUTest/MemoryLeakDetector.h
@@ -143,7 +143,7 @@ struct MemoryLeakDetectorTable
 			MemLeakPeriod period);
 
 private:
-	int hash(char* memory);
+	unsigned long hash(char* memory);
 
 	enum
 	{

--- a/lib/CppUTest/include/CppUTest/PlatformSpecificFunctions.h
+++ b/lib/CppUTest/include/CppUTest/PlatformSpecificFunctions.h
@@ -57,12 +57,12 @@ void SetPlatformSpecificTimeStringMethod(const char* (*platformMethod)());
 
 /* String operations */
 int PlatformSpecificAtoI(const char*str);
-int PlatformSpecificStrLen(const char* str);
+size_t PlatformSpecificStrLen(const char* str);
 char* PlatformSpecificStrCat(char* s1, const char* s2);
 char* PlatformSpecificStrCpy(char* s1, const char* s2);
-char* PlatformSpecificStrNCpy(char* s1, const char* s2, unsigned int size);
+char* PlatformSpecificStrNCpy(char* s1, const char* s2, size_t size);
 int PlatformSpecificStrCmp(const char* s1, const char* s2);
-int PlatformSpecificStrNCmp(const char* s1, const char* s2, unsigned int size);
+int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size);
 char* PlatformSpecificStrStr(const char* s1, const char* s2);
 int PlatformSpecificVSNprintf(char *str, unsigned int size, const char* format,
 		va_list va_args_list);
@@ -83,9 +83,9 @@ int PlatformSpecificPutchar(int c);
 void PlatformSpecificFlush();
 
 /* Dynamic Memory operations */
-void* PlatformSpecificMalloc(unsigned int size);
-void* PlatformSpecificRealloc(void* memory, unsigned int size);
+void* PlatformSpecificMalloc(size_t size);
+void* PlatformSpecificRealloc(void* memory, size_t size);
 void PlatformSpecificFree(void* memory);
-void* PlatformSpecificMemCpy(void* s1, const void* s2, unsigned int size);
+void* PlatformSpecificMemCpy(void* s1, const void* s2, size_t size);
 
 #endif

--- a/lib/CppUTest/src/Failure.cpp
+++ b/lib/CppUTest/src/Failure.cpp
@@ -68,7 +68,7 @@ SimpleString Failure::getTestName() const
 	return testName;
 }
 
-int Failure::getLineNumber() const
+long Failure::getLineNumber() const
 {
 	return lineNumber;
 }

--- a/lib/CppUTest/src/MemoryLeakDetector.cpp
+++ b/lib/CppUTest/src/MemoryLeakDetector.cpp
@@ -171,9 +171,9 @@ bool MemoryLeakDetectorList::hasLeaks(MemLeakPeriod period)
 
 /////////////////////////////////////////////////////////////
 
-int MemoryLeakDetectorTable::hash(char* memory)
+unsigned long MemoryLeakDetectorTable::hash(char* memory)
 {
-	return ((size_t) memory) % hash_prime;
+	return (unsigned long)((size_t)memory % hash_prime);
 }
 
 void MemoryLeakDetectorTable::clearAllAccounting(MemLeakPeriod period)
@@ -220,7 +220,7 @@ MemoryLeakDetectorNode* MemoryLeakDetectorTable::getFirstLeak(
 MemoryLeakDetectorNode* MemoryLeakDetectorTable::getNextLeak(
 		MemoryLeakDetectorNode* leak, MemLeakPeriod period)
 {
-	int i = hash(leak->memory);
+	unsigned long i = hash(leak->memory);
 	MemoryLeakDetectorNode* node = table[i].getNextLeak(leak, period);
 	if (node) return node;
 
@@ -295,7 +295,7 @@ void MemoryLeakDetector::reportFailure(const char* message,
 	reporter->fail(output_buffer.toString());
 }
 
-int calculateIntAlignedSize(size_t size)
+size_t calculateIntAlignedSize(size_t size)
 {
 	return (sizeof(int) - (size % sizeof(int))) + size;
 }

--- a/lib/CppUTest/src/SimpleString.cpp
+++ b/lib/CppUTest/src/SimpleString.cpp
@@ -29,7 +29,7 @@
 #include "CppUTest/SimpleString.h"
 #include "CppUTest/PlatformSpecificFunctions.h"
 
-static char* allocString(int size)
+static char* allocString(size_t size)
 {
 	return new char[size];
 }
@@ -50,7 +50,7 @@ SimpleString::SimpleString(const char *otherBuffer)
 		buffer = getEmptryString();
 	}
 	else {
-		int len = PlatformSpecificStrLen(otherBuffer) + 1;
+		size_t len = PlatformSpecificStrLen(otherBuffer) + 1;
 		buffer = allocString(len);
 		PlatformSpecificStrCpy(buffer, otherBuffer);
 	}
@@ -58,7 +58,7 @@ SimpleString::SimpleString(const char *otherBuffer)
 
 SimpleString::SimpleString(const char *other, int repeatCount)
 {
-	int len = PlatformSpecificStrLen(other) * repeatCount + 1;
+	size_t len = PlatformSpecificStrLen(other) * repeatCount + 1;
 	buffer = allocString(len);
 	char* next = buffer;
 	for (int i = 0; i < repeatCount; i++) {
@@ -104,8 +104,8 @@ bool SimpleString::startsWith(const SimpleString& other) const
 
 bool SimpleString::endsWith(const SimpleString& other) const
 {
-	int buffer_length = PlatformSpecificStrLen(buffer);
-	int other_buffer_length = PlatformSpecificStrLen(other.buffer);
+	size_t buffer_length = PlatformSpecificStrLen(buffer);
+	size_t other_buffer_length = PlatformSpecificStrLen(other.buffer);
 	if (other_buffer_length == 0) return true;
 	if (buffer_length == 0) return false;
 	if (buffer_length < other_buffer_length) return false;
@@ -135,7 +135,7 @@ void SimpleString::split(const SimpleString& split, SimpleStringCollection& col)
 	for (int i = 0; i < num; ++i) {
 		prev = str;
 		str = PlatformSpecificStrStr(str, split.buffer) + 1;
-		int len = str - prev;
+		size_t len = str - prev;
 		char* sub = allocString(len + 1);
 		PlatformSpecificStrNCpy(sub, prev, len);
 		sub[len] = '\0';
@@ -158,15 +158,15 @@ void SimpleString::replace(char to, char with)
 void SimpleString::replace(const char* to, const char* with)
 {
 	int c = count(to);
-	int len = size();
-	int tolen = PlatformSpecificStrLen(to);
-	int withlen = PlatformSpecificStrLen(with);
+	size_t len = size();
+	size_t tolen = PlatformSpecificStrLen(to);
+	size_t withlen = PlatformSpecificStrLen(with);
 
-	int newsize = len + (withlen * c) - (tolen * c) + 1;
+	size_t newsize = len + (withlen * c) - (tolen * c) + 1;
 
 	if (newsize) {
 		char* newbuf = allocString(newsize);
-		for (int i = 0, j = 0; i < len;) {
+		for (size_t i = 0, j = 0; i < len;) {
 			if (PlatformSpecificStrNCmp(&buffer[i], to, tolen) == 0) {
 				PlatformSpecificStrNCpy(&newbuf[j], with, withlen);
 				j += withlen;

--- a/lib/CppUTest/src/UtestPlatformGcc.cpp
+++ b/lib/CppUTest/src/UtestPlatformGcc.cpp
@@ -292,7 +292,7 @@ static long TimeInMillisImplementation()
 	struct timeval tv;
 	struct timezone tz;
 	gettimeofday(&tv, &tz);
-	return (tv.tv_sec * 1000) + (long)(tv.tv_usec * 0.001);
+	return (tv.tv_sec * 1000) + (long)((double)tv.tv_usec * 0.001);
 }
 
 static long (*timeInMillisFp) () = TimeInMillisImplementation;
@@ -332,7 +332,7 @@ int PlatformSpecificAtoI(const char*str)
    return atoi(str);
 }
 
-int PlatformSpecificStrLen(const char* str)
+size_t PlatformSpecificStrLen(const char* str)
 {
    return strlen(str);
 }
@@ -347,7 +347,7 @@ char* PlatformSpecificStrCpy(char* s1, const char* s2)
    return strcpy(s1, s2);
 }
 
-char* PlatformSpecificStrNCpy(char* s1, const char* s2, unsigned int size)
+char* PlatformSpecificStrNCpy(char* s1, const char* s2, size_t size)
 {
    return strncpy(s1, s2, size);
 }
@@ -357,7 +357,7 @@ int PlatformSpecificStrCmp(const char* s1, const char* s2)
    return strcmp(s1, s2);
 }
 
-int PlatformSpecificStrNCmp(const char* s1, const char* s2, unsigned int size)
+int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size)
 {
    return strncmp(s1, s2, size);
 }
@@ -396,12 +396,12 @@ int PlatformSpecificPutchar(int c)
   return putchar(c);
 }
 
-void* PlatformSpecificMalloc(unsigned int size)
+void* PlatformSpecificMalloc(size_t size)
 {
    return malloc(size);
 }
 
-void* PlatformSpecificRealloc (void* memory, unsigned int size)
+void* PlatformSpecificRealloc (void* memory, size_t size)
 {
    return realloc(memory, size);
 }
@@ -411,7 +411,7 @@ void PlatformSpecificFree(void* memory)
    free(memory);
 }
 
-void* PlatformSpecificMemCpy(void* s1, const void* s2, unsigned int size)
+void* PlatformSpecificMemCpy(void* s1, const void* s2, size_t size)
 {
    return memcpy(s1, s2, size);
 }

--- a/lib/CppUTest/src/UtestPlatformVisualCpp.cpp
+++ b/lib/CppUTest/src/UtestPlatformVisualCpp.cpp
@@ -346,7 +346,7 @@ int PlatformSpecificAtoI(const char*str)
    return atoi(str);
 }
 
-int PlatformSpecificStrLen(const char* str)
+size_t PlatformSpecificStrLen(const char* str)
 {
    return strlen(str);
 }
@@ -361,7 +361,7 @@ char* PlatformSpecificStrCpy(char* s1, const char* s2)
    return strcpy(s1, s2);
 }
 
-char* PlatformSpecificStrNCpy(char* s1, const char* s2, unsigned int size)
+char* PlatformSpecificStrNCpy(char* s1, const char* s2, size_t size)
 {
    return strncpy(s1, s2, size);
 }
@@ -371,7 +371,7 @@ int PlatformSpecificStrCmp(const char* s1, const char* s2)
    return strcmp(s1, s2);
 }
 
-int PlatformSpecificStrNCmp(const char* s1, const char* s2, unsigned int size)
+int PlatformSpecificStrNCmp(const char* s1, const char* s2, size_t size)
 {
    return strncmp(s1, s2, size);
 }
@@ -427,12 +427,12 @@ int PlatformSpecificPutchar(int c)
   return putchar(c);
 }
 
-void* PlatformSpecificMalloc(unsigned int size)
+void* PlatformSpecificMalloc(size_t size)
 {
    return malloc(size);
 }
 
-void* PlatformSpecificRealloc (void* memory, unsigned int size)
+void* PlatformSpecificRealloc (void* memory, size_t size)
 {
    return realloc(memory, size);
 }
@@ -442,7 +442,7 @@ void PlatformSpecificFree(void* memory)
    free(memory);
 }
 
-void* PlatformSpecificMemCpy(void* s1, const void* s2, unsigned int size)
+void* PlatformSpecificMemCpy(void* s1, const void* s2, size_t size)
 {
    return memcpy(s1, s2, size);
 }


### PR DESCRIPTION
These have been resolved upstream, but the runtime is currently using
an older version that had been extended with multi-threading suppport.