### PR TITLE
Build rockylinux-9-dev container

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -54,6 +54,7 @@ jobs:
       matrix:
         container:
           - rockylinux-8-dev
+          - rockylinux-9-dev
           - debian-11-arm-dev
           - opensuse-leap-15-dev
           - ubuntu-18.04-dev

--- a/container/rockylinux-9-dev/Dockerfile
+++ b/container/rockylinux-9-dev/Dockerfile
@@ -1,0 +1,53 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/
+
+FROM rockylinux:9
+
+# Optionally override uid of default user in container, e.g.,
+# docker build --build-arg uid=1001 ...
+ARG uid
+
+WORKDIR /work
+
+# Before using a new script, update .github/workflows/container.yml
+# to extend the `paths` on which the workflow runs.
+COPY scripts/. ./
+
+RUN \
+  sed -i '/^\[crb\]$/,/^\[/s#^enabled=0$#enabled=1#' /etc/yum.repos.d/rocky.repo \
+  && grep '^enabled=1$' /etc/yum.repos.d/rocky.repo \
+  && yum -y upgrade \
+  && yum -y install \
+  cmake \
+  curl \
+  elfutils-libelf-devel \
+  gcc \
+  gcc-c++ \
+  git \
+  jq \
+  libasan \
+  liblsan \
+  libnsl \
+  libtsan \
+  libubsan \
+  libxcrypt-compat \
+  make \
+  ninja-build \
+  perl \
+  python3 \
+  sudo \
+  which \
+  zlib-devel \
+  && yum -y clean all \
+  && ./install_aocl.sh /opt/aocl \
+  && useradd --system ${uid:+--uid "$uid"} --user-group --shell /sbin/nologin --create-home --home-dir /home/build build \
+  && echo 'build ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/build \
+  && rm -rf "$PWD"
+
+USER build
+WORKDIR /home/build
+
+ENV PATH="/opt/aocl/hld/bin:$PATH"
+RUN aoc -version


### PR DESCRIPTION
Build rockylinux-9-dev container

https://docs.rockylinux.org/release_notes/9_0/

As of Rocky Linux 9 build tools such as CMake and Ninja are in the CRB
Code Ready Builder repository, versus PowerTools in Rocky Linux 8.

https://wiki.rockylinux.org/rocky/repo/#base-repositories

ncurses-compat-libs is no longer shipped in RHEL 9.

libcrypt.so.1 is needed by the perl interpreter shipped with aocl and
has been deprecated in RHEL 9, where libcrypt.so.1 is provided in the
package libxcrypt-compat. libcrypt.so.1 will be removed in RHEL 10.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.0_release_notes/deprecated_functionality
https://bugzilla.redhat.com/show_bug.cgi?id=2034569

Signed-off-by: Peter Colberg <peter.colberg@intel.com>