### PR TITLE
Print Kernel hang status only in debug mode

### DIFF
--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -1678,7 +1678,8 @@ void acl_kernel_if_check_kernel_status(acl_kernel_if *kern) {
 
   if (kern->last_kern_update != 0 &&
       (acl_kernel_if_get_time_us(kern) - kern->last_kern_update >
-       10 * 1000000)) {
+       10 * 1000000) &&
+      kern->io.debug_verbosity > 0) {
     kern->last_kern_update = acl_kernel_if_get_time_us(kern);
     kern->io.printf(
         "No kernel updates in approximately 10 seconds for device %u",


### PR DESCRIPTION
In the earlier commit aeff9bbd95a22bf56b87912e6cc0b6192561e79c, this guarding conditions for the messages if (kern->io.debug_verbosity > 0) was removed accidentally, now adding it back.

Thanks @sophimao for discovering this regression.

Now the Runtime only prints the Kernel hang message in the debug mode.