### PR TITLE
Implement runtime support for device global with init_mode reprogram

### DIFF
--- a/include/acl.h
+++ b/include/acl.h
@@ -498,10 +498,39 @@ typedef class acl_device_program_info_t *acl_device_program_info;
  */
 #define ACL_MEM_CAPABILITY_P2P (1 << 3)
 
+// Enum values here need to match the SPIRV spec for device global in
+// https://github.com/intel/llvm/blob/44c6437684d64aba82d5a3de0e4bbe21d2b1f7ce/sycl/doc/design/spirv-extensions/SPV_INTEL_global_variable_decorations.asciidoc
+// ACL_DEVICE_GLOBAL_HOST_ACCESS_TYPE_COUNT is used for validation
+// in autodiscovery string parsing and should remain the last constant
+// in the enum.
+typedef enum {
+  ACL_DEVICE_GLOBAL_HOST_ACCESS_READ_ONLY,
+  ACL_DEVICE_GLOBAL_HOST_ACCESS_WRITE_ONLY,
+  ACL_DEVICE_GLOBAL_HOST_ACCESS_READ_WRITE,
+  ACL_DEVICE_GLOBAL_HOST_ACCESS_NONE,
+
+  ACL_DEVICE_GLOBAL_HOST_ACCESS_TYPE_COUNT
+} acl_device_global_host_access_t;
+
+// Enum values here also need to match the SPIRV spec for device
+// global in the above link for acl_device_global_host_access_t.
+// ACL_DEVICE_GLOBAL_INIT_MODE_TYPE_COUNT is used for validation in
+// autodiscovery string parsing and should remain the last constant
+// in the enum.
+typedef enum {
+  ACL_DEVICE_GLOBAL_INIT_MODE_REPROGRAM,
+  ACL_DEVICE_GLOBAL_INIT_MODE_RESET,
+
+  ACL_DEVICE_GLOBAL_INIT_MODE_TYPE_COUNT
+} acl_device_global_init_mode_t;
+
 // Definition of device global.
 struct acl_device_global_mem_def_t {
-  uint32_t address;
+  uint64_t address;
   uint32_t size;
+  acl_device_global_host_access_t host_access;
+  acl_device_global_init_mode_t init_mode;
+  bool implement_in_csr;
 };
 
 // Part of acl_device_def_t where members are populated from the information

--- a/include/acl_kernel.h
+++ b/include/acl_kernel.h
@@ -54,6 +54,13 @@ void acl_receive_kernel_update(int activation_id, cl_int status);
 // safe to submit a kernel with subbuffers to the device_op_queue
 int acl_kernel_has_unmapped_subbuffers(acl_mem_migrate_t *mem_migration);
 
+// Checks if the program currently loaded on the passed-in device contains
+// any device globals with reprogram init mode. When a kernel is submitted
+// for the first time and this function returns true, a force reprogram will
+// be scheduled even when the kernel binary hash matches the hash of the
+// currently loaded program.
+bool acl_device_has_reprogram_device_globals(cl_device_id device);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif


### PR DESCRIPTION
- Change to autodiscovery string: add fields in device global for device global attributes, including host_access, init_mode, and implement_in_csr
- Change to kernel: if the device to which kernel is to be launched contains device global with init_mode reprogram, force reprogram device before kernel launch