### PR TITLE
Install ncurses-compat-libs in rockylinux-9-dev container

### DIFF
--- a/container/rockylinux-9-dev/Dockerfile
+++ b/container/rockylinux-9-dev/Dockerfile
@@ -18,6 +18,8 @@ COPY scripts/. ./
 RUN \
   sed -i '/^\[crb\]$/,/^\[/s#^enabled=0$#enabled=1#' /etc/yum.repos.d/rocky.repo \
   && grep '^enabled=1$' /etc/yum.repos.d/rocky.repo \
+  && sed -i '/^\[devel\]$/,/^\[/s#^enabled=0$#enabled=1#' /etc/yum.repos.d/rocky-devel.repo \
+  && grep '^enabled=1$' /etc/yum.repos.d/rocky-devel.repo \
   && yum -y upgrade \
   && yum -y install \
   cmake \
@@ -34,6 +36,7 @@ RUN \
   libubsan \
   libxcrypt-compat \
   make \
+  ncurses-compat-libs \
   ninja-build \
   perl \
   python3 \


### PR DESCRIPTION
This provides libtinfo.so.5 which is needed to run aocl-clang.

ncurses-compat-libs is provided in the devel repository, which provides
dependencies or devel packages that may not be provided by upstream.

https://wiki.rockylinux.org/rocky/repo/#notes-on-devel
https://bugzilla.redhat.com/show_bug.cgi?id=2117930

Signed-off-by: Peter Colberg <peter.colberg@intel.com>