### PR TITLE
Update zlib to 1.2.13

### DIFF
--- a/scripts/install_zlib.ps1
+++ b/scripts/install_zlib.ps1
@@ -6,11 +6,11 @@
 
 Param(
   [Parameter(Mandatory)]$installdir,
-  $version="1.2.12",
+  $version="1.2.13",
   $builddir="zlib-$version",
   $archive="zlib-$version.tar.gz",
   $archive_url="https://zlib.net/fossils/$archive",
-  $sha256="91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
+  $sha256="b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
 )
 
 $ErrorActionPreference = "Stop"


### PR DESCRIPTION
This resolves [CVE-2022-37434](https://nvd.nist.gov/vuln/detail/CVE-2022-37434).