### PR TITLE
Avoid changing ownership of workspace files in container workflows

### DIFF
--- a/.github/workflows/bdba.yml
+++ b/.github/workflows/bdba.yml
@@ -47,9 +47,6 @@ jobs:
     environment: bdba
 
     steps:
-      - name: change ownership of workspace to current user
-        run: sudo chown -R build:build .
-
       - name: checkout code
         uses: actions/checkout@v2
 
@@ -90,7 +87,3 @@ jobs:
 
       - name: print upload id
         run: jq --exit-status .results.product_id upload.json
-
-      - name: revert ownership of workspace to root
-        run: sudo chown -R root:root .
-        if: always()

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -80,9 +80,6 @@ jobs:
     continue-on-error: true
 
     steps:
-      - name: change ownership of workspace to current user
-        run: sudo chown -R build:build .
-
       - name: checkout code
         uses: actions/checkout@v2
 
@@ -141,7 +138,3 @@ jobs:
           name: manifests-${{ matrix.image }}-${{ matrix.config }}-${{ github.run_id }}
           path: build/install_manifest*.txt
           if-no-files-found: error
-
-      - name: revert ownership of workspace to root
-        run: sudo chown -R root:root .
-        if: always()

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -39,9 +39,6 @@ jobs:
       image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-20.04-clang:main
 
     steps:
-      - name: change ownership of workspace to current user
-        run: sudo chown -R build:build .
-
       - name: checkout code
         uses: actions/checkout@v2
 
@@ -50,7 +47,3 @@ jobs:
 
       - name: ensure source files are unchanged
         run: git diff --exit-code
-
-      - name: revert ownership of workspace to root
-        run: sudo chown -R root:root .
-        if: always()

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,9 +41,6 @@ jobs:
       TMP_DIR: /home/build
 
     steps:
-      - name: change ownership of workspace to current user
-        run: sudo chown -R build:build .
-      
       - name: checkout main branch
         uses: actions/checkout@v2
         with:
@@ -75,7 +72,3 @@ jobs:
       
       - name: coverage status
         run: ./scripts/coverage_diff.py "$TMP_DIR/child_build" "$TMP_DIR/parent_build"
-
-      - name: revert ownership of workspace to root
-        run: sudo chown -R root:root .
-        if: always()

--- a/.github/workflows/klocwork-main.yml
+++ b/.github/workflows/klocwork-main.yml
@@ -56,9 +56,6 @@ jobs:
       KLOCWORK_PROJECT: ${{ secrets.KLOCWORK_PROJECT }}
 
     steps:
-      - name: change ownership of workspace to current user
-        run: sudo chown -R klocwork:klocwork .
-
       - name: checkout code
         uses: actions/checkout@v2
 
@@ -84,7 +81,3 @@ jobs:
 
       - name: publish issues to Klocwork server
         run: kwadmin --url "$KLOCWORK_URL" load "$KLOCWORK_PROJECT" kwtables
-
-      - name: revert ownership of workspace to root
-        run: sudo chown -R root:root .
-        if: always()

--- a/.github/workflows/klocwork-pull-request.yml
+++ b/.github/workflows/klocwork-pull-request.yml
@@ -42,9 +42,6 @@ jobs:
       image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-20.04-klocwork-desktop-tools:main
 
     steps:
-      - name: change ownership of workspace to current user
-        run: sudo chown -R klocwork:klocwork .
-
       - name: create local Klocwork project
         run: |
           mkdir -p /home/klocwork/parent
@@ -112,7 +109,3 @@ jobs:
             kwcheck list --id "$NEW_ISSUE_ID" -F detailed --project-dir /home/klocwork/child/.kwlp --settings-dir /home/klocwork/child/.kwps
           fi
           test -z "$NEW_ISSUE_ID"
-
-      - name: revert ownership of workspace to root
-        run: sudo chown -R root:root .
-        if: always()

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -57,9 +57,6 @@ jobs:
     continue-on-error: true
 
     steps:
-      - name: change ownership of workspace to current user
-        run: sudo chown -R build:build .
-
       - name: checkout code
         uses: actions/checkout@v2
 
@@ -93,7 +90,3 @@ jobs:
         with:
           name: tsan-report
           path: build/Testing/Temporary/LastTest.log
-
-      - name: revert ownership of workspace to root
-        run: sudo chown -R root:root .
-        if: always()


### PR DESCRIPTION
This avoids mismatching ownership of workspace files when running both container and non-container workflows on the same self-hosted runner.

Our self-hosted runners are configured to align the out-of-container runner user with the in-container non-root user. Changing the ownership of the workspace to the in-container root user makes them unwritable to the out-of-container runner user, which breaks non-container workflows.