### PR TITLE
Migrate workflows from deprecated set-output to environment file

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -64,7 +64,7 @@ jobs:
         id: msvc
         run: |
           $installationPath = & vswhere -latest -property installationPath
-          echo "::set-output name=path::$installationPath\vc\auxiliary\build\vcvars64.bat"
+          "path=$installationPath\vc\auxiliary\build\vcvars64.bat" >> $env:GITHUB_OUTPUT
 
       - name: cache libelf
         id: cache-libelf

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -80,7 +80,7 @@ jobs:
         id: tag
         run: |
           ref=$(echo "$ref" | sed 's#^refs/\(\|heads/\|tags/\)##')
-          echo "::set-output name=tag::${ref//[^a-zA-Z0-9_.]/-}"
+          echo "tag=${ref//[^a-zA-Z0-9_.]/-}" >> "$GITHUB_OUTPUT"
         env:
           ref: ${{ github.ref }}
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/