### PR TITLE
Upgrade workflows to actions/checkout@v3

### DIFF
--- a/.github/workflows/bdba.yml
+++ b/.github/workflows/bdba.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: create build directory
         run: mkdir build

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: query distribution
         run: cat /etc/os-release

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: query path of compiler setup script
         id: msvc

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: run clang-format on source files
         run: ./scripts/clang-format.sh --verbose

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # https://docs.docker.com/engine/reference/commandline/tag/#extended-description
       # > A tag name must be valid ASCII and may contain lowercase and

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: checkout main branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.base_ref }}
       
@@ -59,7 +59,7 @@ jobs:
         run: cd "$TMP_DIR/parent_build" && ctest -T Test -T Coverage
 
       - name: checkout current branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: create child build files
         run: cd "$TMP_DIR/child_build" && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Debug -DACL_CODE_COVERAGE=ON

--- a/.github/workflows/klocwork-main.yml
+++ b/.github/workflows/klocwork-main.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: configure Klocwork token
         run: |

--- a/.github/workflows/klocwork-pull-request.yml
+++ b/.github/workflows/klocwork-pull-request.yml
@@ -48,7 +48,7 @@ jobs:
           kwcheck create --project-dir /home/klocwork/parent/.kwlp --settings-dir /home/klocwork/parent/.kwps
 
       - name: checkout base ref
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.base_ref }}
 
@@ -73,7 +73,7 @@ jobs:
           cp -r /home/klocwork/parent/.kwlp /home/klocwork/parent/.kwps /home/klocwork/child
 
       - name: checkout head ref
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: create build files of head ref
         run: |

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: query distribution
         run: cat /etc/os-release

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # See Git Glossary for pathspec patterns
       # https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefpathspecapathspec


### PR DESCRIPTION
Node.js 12 actions are deprecated.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

https://github.com/actions/checkout/blob/1f9a0c22da41e6ebfa534300ef656657ea2c6707/README.md#whats-new