### PR TITLE
Pass pkg_editor tests with address sanitizer

### DIFF
--- a/lib/pkg_editor/src/pkg_editor.c
+++ b/lib/pkg_editor/src/pkg_editor.c
@@ -1107,6 +1107,16 @@ int acl_pkg_close_file(acl_pkg_file *pkg) {
   // allocated buffers used to store file contents may be freed.
   free_buffers(pkg);
 
+  // If the file is not read-only, the string table data buffer
+  // has been dynamically allocated in add_required_parts() when
+  // creating a new file, or make_string_table_extensible() when
+  // appending to an existing file, and may be freed now.
+  if (pkg->writable) {
+    Elf_Data *data = get_name_data_ptr(pkg);
+    assert(data);
+    free(data->d_buf);
+  }
+
   // Should be albe to call elf_end even if elf_update failed
   while (elf_end(pkg->elf)) {
     if (pkg->show_info)


### PR DESCRIPTION
This resolves various memory leaks in the `pkg_editor` library. The ELF library requires the user to ensure that a buffer assigned to [`d_buf` in the `Elf_Data`](https://man.openbsd.org/elf_newdata.3) struct is alive at the time [`elf_update()`](https://man.openbsd.org/elf_update.3) is called. This was previously achieved by allocating buffers and not freeing them at all, which leaks the allocated memory. To resolve the memory leaks, these commits either introduce statically allocated buffers, or track the dynamically allocated buffers and free them when closing the ELF file.

(Since I could not find detailed man pages for elfutils, I linked to the OpenBSD man pages above which are strictly for the OpenBSD implementation of libelf.)

This is a prerequisite of https://github.com/intel/fpga-runtime-for-opencl/pull/118