### PR TITLE
Skip csr version check when cra_ring_root doesn't exist

### DIFF
--- a/include/acl.h
+++ b/include/acl.h
@@ -526,6 +526,8 @@ typedef struct acl_device_def_autodiscovery_t {
   // Device global definition.
   std::unordered_map<std::string, acl_device_global_mem_def_t>
       device_global_mem_defs;
+  bool cra_ring_root_exist =
+      true; // Set the default value to true for backwards compatibility flows.
 } acl_device_def_autodiscovery_t;
 
 typedef struct acl_device_def_t {

--- a/src/acl_auto_configure.cpp
+++ b/src/acl_auto_configure.cpp
@@ -99,6 +99,25 @@ static bool read_uint_counters(const std::string &str,
   return true;
 }
 
+// Reads the next word in str and converts it into a boolean.
+// Returns true if a valid integer was read or false if an error occurred.
+// pos is updated to the position immediately following the parsed word
+// even if an error occurs.
+static bool read_bool_counters(const std::string &str,
+                               std::string::size_type &pos, bool &val,
+                               std::vector<int> &counters) noexcept {
+  std::string result;
+  pos = read_word(str, pos, result);
+  decrement_section_counters(counters);
+  try {
+    val = static_cast<bool>(std::stoi(result));
+  } catch (const std::exception &e) {
+    UNREFERENCED_PARAMETER(e);
+    return false;
+  }
+  return true;
+}
+
 // Reads the next word in str and converts it into an unsigned.
 // Returns true if a valid integer was read or false if an error occurred.
 // pos is updated to the position immediately following the parsed word
@@ -1050,6 +1069,12 @@ bool acl_load_device_def_from_str(const std::string &config_str,
   if (result && counters.back() > 0) {
     result = read_device_global_mem_defs(
         config_str, curr_pos, devdef.device_global_mem_defs, counters, err_str);
+  }
+
+  // Check whether csr_ring_root exist in the IP.
+  if (result && counters.back() > 0) {
+    result = read_bool_counters(config_str, curr_pos,
+                                devdef.cra_ring_root_exist, counters);
   }
 
   // forward compatibility: bypassing remaining fields at the end of device

--- a/test/acl_auto_configure_test.cpp
+++ b/test/acl_auto_configure_test.cpp
@@ -482,11 +482,11 @@ TEST(auto_configure, many_ok_forward_compatibility) {
   // sections and subsections to check forward compatibility
 
   std::string str(VERSIONIDTOSTR(
-      ACL_AUTO_CONFIGURE_VERSIONID) " 28 "
+      ACL_AUTO_CONFIGURE_VERSIONID) " 29 "
                                     "sample40byterandomhash000000000000000000 "
                                     "a10gx 0 1 15 DDR 2 1 6 0 2147483648 100 "
                                     "100 100 100 200 200 200 200 0 0 0 0 2 "
-                                    "1 name1 1 name2 47 "
+                                    "1 name1 name2 0 0 47 "
                                     "40 external_sort_stage_0 0 128 1 0 0 1 0 "
                                     "1 0 1 10 0 0 4 1 0 0 0 500 500 500 0 0 "
                                     "0 0 1 1 1 3 1 1 1 3 1 0 0 800 800 800 "
@@ -1409,4 +1409,64 @@ TEST(auto_configure, two_streaming_args_and_non_streaming_kernel) {
   for (size_t i = 2; i < args.size(); ++i) {
     CHECK(!args[i].streaming_arg_info_available);
   }
+}
+
+TEST(auto_configure, cra_ring_root_not_exist) {
+  const std::string config_str{
+      "23 50 2ccb683dee8e34a004c1a27e6d722090a8cc684d custom_ipa 0 1 9 0 2 1 2 "
+      "0 2199023255552 3 "
+      "- 0 6 5 ZTSZ4mainE4MyIP_arg_input_a 1 0 8 32768 "
+      "ZTSZ4mainE4MyIP_arg_input_b 1 0 8 32768 ZTSZ4mainE4MyIP_arg_input_c"
+      " 1 0 8 32768 ZTSZ4mainE4MyIP_arg_n 1 0 4 32768 "
+      "ZTSZ4mainE4MyIP_streaming_start 1 0 0 32768 "
+      "ZTSZ4mainE4MyIP_streaming_done"
+      " 0 1 0 32768 0 0 0 0 1 64 _ZTSZ4mainE4MyIP 0 128 1 0 0 1 0 1 0 4 8 2 1 "
+      "8 4 0 0 1 ZTSZ4mainE4MyIP_arg_input_a 8"
+      " 2 1 8 4 0 0 1 ZTSZ4mainE4MyIP_arg_input_b 8 2 1 8 4 0 0 1 "
+      "ZTSZ4mainE4MyIP_arg_input_c"
+      " 8 0 0 4 1 0 0 1 ZTSZ4mainE4MyIP_arg_n 0 0 0 0 1 1 1 3 1 1 1 3 1 1 1 "
+      "ZTSZ4mainE4MyIP_streaming_start"
+      " ZTSZ4mainE4MyIP_streaming_done"};
+
+  acl_device_def_autodiscovery_t devdef;
+  {
+    bool result;
+    std::string err_str;
+    ACL_LOCKED(result =
+                   acl_load_device_def_from_str(config_str, devdef, err_str));
+    std::cerr << err_str;
+    CHECK(result);
+  }
+
+  CHECK_EQUAL(0, devdef.cra_ring_root_exist);
+}
+
+TEST(auto_configure, cra_ring_root_exist) {
+  const std::string config_str{
+      "23 50 2ccb683dee8e34a004c1a27e6d722090a8cc684d custom_ipa 0 1 9 0 2 1 2 "
+      "0 2199023255552 3 "
+      "- 0 6 5 ZTSZ4mainE4MyIP_arg_input_a 1 0 8 32768 "
+      "ZTSZ4mainE4MyIP_arg_input_b 1 0 8 32768 ZTSZ4mainE4MyIP_arg_input_c"
+      " 1 0 8 32768 ZTSZ4mainE4MyIP_arg_n 1 0 4 32768 "
+      "ZTSZ4mainE4MyIP_streaming_start 1 0 0 32768 "
+      "ZTSZ4mainE4MyIP_streaming_done"
+      " 0 1 0 32768 0 0 0 1 1 64 _ZTSZ4mainE4MyIP 0 128 1 0 0 1 0 1 0 4 8 2 1 "
+      "8 4 0 0 1 ZTSZ4mainE4MyIP_arg_input_a 8"
+      " 2 1 8 4 0 0 1 ZTSZ4mainE4MyIP_arg_input_b 8 2 1 8 4 0 0 1 "
+      "ZTSZ4mainE4MyIP_arg_input_c"
+      " 8 0 0 4 1 0 0 1 ZTSZ4mainE4MyIP_arg_n 0 0 0 0 1 1 1 3 1 1 1 3 1 1 1 "
+      "ZTSZ4mainE4MyIP_streaming_start"
+      " ZTSZ4mainE4MyIP_streaming_done"};
+
+  acl_device_def_autodiscovery_t devdef;
+  {
+    bool result;
+    std::string err_str;
+    ACL_LOCKED(result =
+                   acl_load_device_def_from_str(config_str, devdef, err_str));
+    std::cerr << err_str;
+    CHECK(result);
+  }
+
+  CHECK_EQUAL(1, devdef.cra_ring_root_exist);
 }


### PR DESCRIPTION
In the system integrator, in the auto-discovery string, added a new field at the end of the device section to indicate whether the cra_ring_root exist or not. The runtime will parse the new field from the auto-discovery string and skip csr version check if cra_ring_root doesn't exit. Changed the csr_version to be optional.

Updated the forward-compatibility auto-discovery string test. Note: the previous test had an issue: The number of fields per device global is fixed (here to 1), not variable. I had to update that as well. Cherry picked from: https://github.com/intel/fpga-runtime-for-opencl/pull/133/commits/024154d850e5c13c913c47737d20306cdd8d38b2
