### PR TITLE
workflows: build with warnings as errors on Linux

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -97,6 +97,8 @@ jobs:
         env:
           CC: ${{ matrix.cross }}gcc
           CXX: ${{ matrix.cross }}g++
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
 
       - name: build runtime
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,6 +51,9 @@ jobs:
 
       - name: create parent build files
         run: cd "$TMP_DIR/parent_build" && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Debug -DACL_CODE_COVERAGE=ON
+        env:
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
 
       - name: build parent runtime
         run: cd "$TMP_DIR/parent_build" && ninja -v -k0
@@ -63,6 +66,9 @@ jobs:
 
       - name: create child build files
         run: cd "$TMP_DIR/child_build" && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Debug -DACL_CODE_COVERAGE=ON
+        env:
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
 
       - name: build child runtime
         run: cd "$TMP_DIR/child_build" && ninja -v -k0

--- a/.github/workflows/klocwork-main.yml
+++ b/.github/workflows/klocwork-main.yml
@@ -70,6 +70,9 @@ jobs:
         run: |
           mkdir build
           cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        env:
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
 
       - name: create build specification
         run: kwinject --output kwinject.out ninja -C build -v -j1 -k0

--- a/.github/workflows/klocwork-pull-request.yml
+++ b/.github/workflows/klocwork-pull-request.yml
@@ -56,6 +56,9 @@ jobs:
         run: |
           mkdir build
           cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        env:
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
 
       - name: create build specification of base ref
         run: kwinject --output kwinject.out ninja -C build -v -k0
@@ -79,6 +82,9 @@ jobs:
         run: |
           mkdir build
           cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Debug
+        env:
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
 
       - name: create build specification of head ref
         run: kwinject --output kwinject.out ninja -C build -v -k0

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -73,6 +73,8 @@ jobs:
         env:
           CC: gcc
           CXX: g++
+          CFLAGS: -Werror
+          CXXFLAGS: -Werror
 
       - name: build runtime
         run: |


### PR DESCRIPTION
This enables -Werror in CI only, which will catch new warnings in pull requests, but not break user builds with, e.g., a newer GCC version.