### PR TITLE
Klocwork check null before dereference in acl_profiler.cpp

### DIFF
--- a/src/acl_profiler.cpp
+++ b/src/acl_profiler.cpp
@@ -614,6 +614,7 @@ CL_API_ENTRY cl_int CL_API_CALL clGetProfileDataDeviceIntelFPGA(
                                            "autorun kernel profiling enabled";
       ERR_RET(status, program->context, message);
     }
+    assert(accel_def != NULL);
 
     // use autodiscovery info to find out how many words will be read from the
     // profiler


### PR DESCRIPTION
Fixed the following Klocwork issue:
1. Pointer 'accel_def' returned from call to function 'acl_find_accel_def' at line 605 may be NULL and may be dereferenced at line 620.

`acl_find_accl_def` bails out if the return value would be NULL, therefore ensuring that `accel_def` can never be NULL if `status == CL_SUCCESS`. So an assert statement is included instead after the `status` check, which would rule out NULL return values.
