### PR TITLE
Fix warnings in unit test BSP

### DIFF
--- a/test/fake_bsp/fakegoodbsp.cpp
+++ b/test/fake_bsp/fakegoodbsp.cpp
@@ -282,14 +282,14 @@ AOCL_MMD_CALL int aocl_mmd_read(int handle, aocl_mmd_op_t op, size_t len,
     fprintf(stderr, "Error: Not handling read of 0x%x in unit test\n",
             (unsigned int)offset);
     return -1;
-  case OFFSET_CONFIGURATION_ROM:
-    if (strlen(config_str) <= len) {
-      memcpy(dst, (void *)config_str, len);
-      return 0;
-    } else {
+  case OFFSET_CONFIGURATION_ROM: {
+    const size_t config_len = strlen(config_str);
+    if (!(config_len < len)) {
       return -1;
     }
-    break;
+    memcpy(dst, config_str, config_len + 1);
+    return 0;
+  }
   case OFFSET_COUNTER:
     if (len == sizeof(unsigned int)) {
       memcpy(dst, &offset_counter, len);

--- a/test/fake_bsp/missingfuncbsp.cpp
+++ b/test/fake_bsp/missingfuncbsp.cpp
@@ -267,14 +267,14 @@ AOCL_MMD_CALL int aocl_mmd_read(int handle, aocl_mmd_op_t op, size_t len,
     fprintf(stderr, "Error: Not handling read of 0x%x in unit test\n",
             (unsigned int)offset);
     return -1;
-  case OFFSET_CONFIGURATION_ROM:
-    if (strlen(config_str) <= len) {
-      memcpy(dst, (void *)config_str, len);
-      return 0;
-    } else {
+  case OFFSET_CONFIGURATION_ROM: {
+    const size_t config_len = strlen(config_str);
+    if (!(config_len < len)) {
       return -1;
     }
-    break;
+    memcpy(dst, config_str, config_len + 1);
+    return 0;
+  }
   case OFFSET_COUNTER:
     fprintf(stderr, "Error: Not handling read of 0x%x in unit test\n",
             (unsigned int)offset);


### PR DESCRIPTION
```
commit caa98ebd373d48e5ec063d604347248d9df82ba6
Author: Peter Colberg <peter.colberg@intel.com>
Date:   Thu Nov 17 18:40:39 2022

    fake_bsp: fix out-of-bounds read of OFFSET_CONFIGURATION_ROM
    
    The check failed to account for the trailing null byte, and
    memcpy() read beyond the end of the copied string literal.
    
    Signed-off-by: Peter Colberg <peter.colberg@intel.com>
```
```
commit 7f737cdc93826a36087417004b99c34e7296e9f8
Author: Peter Colberg <peter.colberg@intel.com>
Date:   Thu Nov 17 18:04:25 2022

    fake_bsp: fix stringop-overread warnings with string literals
    
    GCC 11 correctly points out that there is no point in limiting strnlen()
    to a size that is greater than the length of the string literal argument.
    
    test/fake_bsp/fakegoodbsp.cpp:47:26: warning: 'size_t strnlen(const char*, size_t)' specified bound 1204 exceeds source size 16 [-Wstringop-overread]
       47 |     size_t Xlen = strnlen(X, MAX_NAME_SIZE) + 1;                               \
          |                   ~~~~~~~^~~~~~~~~~~~~~~~~~
    
    strnlen() is commonly used with an input buffer that is possibly not
    null-terminated, i.e., contains a truncated string. strnlen() is also
    useful to set an upper bound on the length to consume, e.g., to avoid
    a denial of service. Neither of these use cases apply here.
    
    MAX_NAME_SIZE was previously introduced in acl.h to address Klocwork
    issues relating to missing null termination of strings. The chosen
    1204 is a typo of 1024, but even then, it should be 1023 such that a
    buffer with the trailing null byte occupies 1023 + 1 = 1024 bytes.
    
    Signed-off-by: Peter Colberg <peter.colberg@intel.com>
```