### PR TITLE
workflows: add Coverity static code analysis

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,73 @@
+# Copyright (C) 2021 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+
+name: Coverity
+
+permissions:
+  # Grant read permissions to private container images.
+  packages: read
+
+on:
+  push:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!**/.clang-format'
+      - '!**/COPYING'
+      - '!**/LICENSE'
+      - '!.github/**'
+      - '.github/workflows/coverity.yml'
+      - '!.gitignore'
+      - '!cmake/manifests/**'
+      - '!container/**'
+      - '!docs/**'
+      - '!scripts/**'
+
+  pull_request:
+    paths:
+      - '**'
+      - '!**.md'
+      - '!**/.clang-format'
+      - '!**/COPYING'
+      - '!**/LICENSE'
+      - '!.github/**'
+      - '.github/workflows/coverity.yml'
+      - '!.gitignore'
+      - '!cmake/manifests/**'
+      - '!container/**'
+      - '!docs/**'
+      - '!scripts/**'
+
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - container
+
+    container:
+      image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-22.04-dev:main
+      volumes:
+        - /opt/coverity:/opt/coverity
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release
+      - run: echo /opt/coverity/latest/bin >> "$GITHUB_PATH"
+      # The --compiler names must match those used by CMake.
+      # https://community.synopsys.com/s/article/cov-build-returns-WARNING-No-files-were-emitted-This-may-be-due-to-a-problem-with-your-configuration
+      # https://community.synopsys.com/s/article/Configuring-Your-Compilers-for-Coverity-Analysis
+      - run: cov-configure --config config.xml --template --comptype gcc --compiler cc
+      - run: cov-configure --config config.xml --template --comptype g++ --compiler c++
+      - run: cov-build --config config.xml --dir results ninja -C build -v -k0
+      - run: cov-analyze --config config.xml --dir results --concurrency --security --rule --enable-constraint-fpp --enable-fnptr --enable-virtual
+      - run: cov-format-errors --text-output-style multiline --dir results --filesort --file "$PWD" --strip-path "$PWD" > cov-errors.txt
+      - run: cat cov-errors.txt
+      - uses: actions/upload-artifact@v3
+        with:
+          name: fpga-runtime-for-opencl-${{ github.sha }}-coverity-${{ github.run_id }}
+          path: cov-errors.txt
+          if-no-files-found: error


### PR DESCRIPTION
For now, the workflow only lists the issues. Once the Coverity issues are
resolved, the output of cov-format-errors can be tested for zero length.