### PR TITLE
Klocwork check null before dereference in acl_svm.cpp

### DIFF
--- a/src/acl_svm.cpp
+++ b/src/acl_svm.cpp
@@ -145,6 +145,7 @@ CL_API_ENTRY void *CL_API_CALL clSVMAllocIntelFPGA(cl_context context,
 #endif // SYSTEM_SVM
   svm_entry = context->svm_list;
   context->svm_list = (acl_svm_entry_t *)malloc(sizeof(acl_svm_entry_t));
+  assert(context->svm_list);
 
   context->svm_list->next = svm_entry;
   if (flags & CL_MEM_READ_ONLY) {


### PR DESCRIPTION
Fixed the following Klocwork issue:
1. Pointer 'context->svm_list' returned from call to function 'malloc' at line 147 may be NULL and will be dereferenced at line 149.
Verifying that `malloc` appropriately allocated the memory. The size of `malloc` is not user defined, therefore an assert is more appropriate.