### PR TITLE
acl_device_binary: fix missing assignment operator

### DIFF
--- a/include/acl_device_binary.h
+++ b/include/acl_device_binary.h
@@ -24,6 +24,10 @@ class acl_device_program_info_t;
 // .aocr file).
 class acl_device_binary_t {
 public:
+  acl_device_binary_t() = default;
+  acl_device_binary_t(const acl_device_binary_t &) = delete;
+  acl_device_binary_t &operator=(const acl_device_binary_t &) = delete;
+
   ~acl_device_binary_t() { unload_content(); }
 
   inline void set_dev_prog(acl_device_program_info_t *dev_prog) {


### PR DESCRIPTION
> Class "acl_device_binary_t" owns resources that are freed in its
> destructor but has no user-written assignment operator.

Signed-off-by: Peter Colberg <peter.colberg@intel.com>