### PR TITLE
workflows: use ccache to speed up code coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,13 +3,9 @@
 
 # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
-name: delta coverage checks
+name: code coverage
 
 permissions:
-  # Grant read permissions to repository in case it is not a forked public
-  # repository, but a private repository that was created manually.
-  contents: read
-
   # Grant read permissions to private container images.
   packages: read
 
@@ -32,43 +28,46 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     container:
-      image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-20.04-dev:main
-
-    env:
-      TMP_DIR: /home/build
+      image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-22.04-dev:main
 
     steps:
       - name: checkout main branch
         uses: actions/checkout@v3
         with:
           ref: ${{ github.base_ref }}
-      
-      - name: create build directories
-        run: mkdir "$TMP_DIR/child_build" "$TMP_DIR/parent_build"
+
+      - name: create build directory
+        run: mkdir build
 
       - name: create parent build files
-        run: cd "$TMP_DIR/parent_build" && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Debug -DACL_CODE_COVERAGE=ON
+        run: cd build && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Debug -DACL_CODE_COVERAGE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: build parent runtime
-        run: cd "$TMP_DIR/parent_build" && ninja -v -k0
+        run: cd build && ninja -v -k0
 
       - name: parent runtime coverage scan
-        run: cd "$TMP_DIR/parent_build" && ctest -T Test -T Coverage
+        run: cd build && ctest -T Test -T Coverage
+      
+      - name: save build directory for later comparison
+        run: mv -t "$RUNNER_TEMP" build
 
       - name: checkout current branch
         uses: actions/checkout@v3
 
+      - name: create build directory
+        run: mkdir build
+
       - name: create child build files
-        run: cd "$TMP_DIR/child_build" && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Debug -DACL_CODE_COVERAGE=ON
+        run: cd build && cmake -G Ninja "$GITHUB_WORKSPACE" -DCMAKE_BUILD_TYPE=Debug -DACL_CODE_COVERAGE=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
       - name: build child runtime
-        run: cd "$TMP_DIR/child_build" && ninja -v -k0
+        run: cd build && ninja -v -k0
 
       - name: child runtime coverage scan
-        run: cd "$TMP_DIR/child_build" && ctest -T Test -T Coverage
+        run: cd build && ctest -T Test -T Coverage
       
       - name: coverage status
-        run: ./scripts/coverage_diff.py "$TMP_DIR/child_build" "$TMP_DIR/parent_build"
+        run: ./scripts/coverage_diff.py build "$RUNNER_TEMP"/build


### PR DESCRIPTION
ccache requires the build paths, e.g., for include directories to
be identical in order to reuse the cache between the two builds.

Setting the CCACHE_BASEDIR environment variable to the respective build
directory does not seem to have any effect and does not reuse the cache.

Signed-off-by: Peter Colberg <peter.colberg@intel.com>