### PR TITLE
container: install ccache

### DIFF
--- a/container/debian-11-arm-dev/Dockerfile
+++ b/container/debian-11-arm-dev/Dockerfile
@@ -21,6 +21,7 @@ RUN dpkg --add-architecture armhf \
   && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade \
   build-essential \
   ca-certificates \
+  ccache \
   cmake \
   curl \
   git \

--- a/container/opensuse-leap-15-dev/Dockerfile
+++ b/container/opensuse-leap-15-dev/Dockerfile
@@ -17,6 +17,7 @@ COPY scripts/. ./
 
 RUN zypper -n update \
   && zypper -n install \
+  ccache \
   cmake \
   curl \
   gcc \

--- a/container/ubuntu-18.04-dev/Dockerfile
+++ b/container/ubuntu-18.04-dev/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get -y update \
   && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade \
   build-essential \
   ca-certificates \
+  ccache \
   cmake \
   curl \
   git \

--- a/container/ubuntu-20.04-dev/Dockerfile
+++ b/container/ubuntu-20.04-dev/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get -y update \
   && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade \
   build-essential \
   ca-certificates \
+  ccache \
   cmake \
   curl \
   git \

--- a/container/ubuntu-22.04-dev/Dockerfile
+++ b/container/ubuntu-22.04-dev/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -y update \
   && DEBIAN_FRONTEND=noninteractive apt-get -y dist-upgrade \
   build-essential \
   ca-certificates \
+  ccache \
   clang-format-13 \
   cmake \
   curl \


### PR DESCRIPTION
ccache is not available on Rocky Linux.

Signed-off-by: Peter Colberg <peter.colberg@intel.com>