### PR TITLE
Fixed coverity issue in acl_kernel_if.cpp

### DIFF
--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -453,8 +453,6 @@ static uintptr_t acl_kernel_cra_set_segment(acl_kernel_if *kern,
     acl_kernel_if_write_32b(kern, OFFSET_KERNEL_CRA_SEGMENT,
                             (unsigned int)segment);
     kern->cur_segment = segment;
-    acl_kernel_if_read_32b(kern, OFFSET_KERNEL_CRA_SEGMENT,
-                           (unsigned int *)&segment);
   }
 
   return segment_offset;
@@ -470,8 +468,6 @@ static uintptr_t acl_kernel_cra_set_segment_rom(acl_kernel_if *kern,
     acl_kernel_if_write_32b(kern, OFFSET_KERNEL_CRA_SEGMENT,
                             (unsigned int)segment);
     kern->cur_segment = segment;
-    acl_kernel_if_read_32b(kern, OFFSET_KERNEL_CRA_SEGMENT,
-                           (unsigned int *)&segment);
   }
 
   return segment_offset;
@@ -1613,8 +1609,6 @@ void acl_kernel_if_update_status(acl_kernel_if *kern) {
     acl_kernel_if_write_32b(kern, OFFSET_KERNEL_CRA_SEGMENT,
                             (unsigned int)segment_pre_irq);
     kern->cur_segment = segment_pre_irq;
-    acl_kernel_if_read_32b(kern, OFFSET_KERNEL_CRA_SEGMENT,
-                           (unsigned int *)&segment_pre_irq);
   }
 }
 


### PR DESCRIPTION
Continuation of discussion featured in https://github.com/intel/fpga-runtime-for-opencl/pull/220.
Fixed coverity issue in acl_kernel_if.cpp: Type: Reliance on integer endianness (INCOMPATIBLE_CAST)

In the three instances where this issue happens, the function acl_kernel_if_read_32b is used at the end of the scope to query about what's inside the acl_kernel_if* kern object. However, they don't do anything with the obtained information. I believe this read operation is performed to confirm that the acl_kernel_if* kern has been written properly. So if the read operation successed, then the write operation must have also succeeded as well. The functions employing acl_kernel_if_read_32b are used to return the segment offset. This segment offset is then used to perform another read/write, which return status would then be used for error checking. Therefore, the `acl_kernel_if_read_32b` function is redundant and can be removed from the aformentioned 3 instances.