### PR TITLE
Fixed coverity issues in acl_program.cpp

### DIFF
--- a/src/acl_program.cpp
+++ b/src/acl_program.cpp
@@ -1819,6 +1819,9 @@ static cl_int l_build_from_source_in_dir(acl_device_program_info_t *dev_prog,
   if (status == CL_SUCCESS && context->compiles_programs) {
     for (unsigned i = 0; i < num_build_cmds; i++) {
       struct acl_file_handle_t *cmdfp = acl_fopen(cmdfile[i], "wb");
+      if (debug_mode > 0) {
+        printf(" cmdfp %p\n", cmdfp);
+      }
       size_t bytes_written = 0;
       if (cmdfp) {
         bytes_written = (size_t)acl_fprintf(cmdfp, "%s", cmd[i].c_str());
@@ -1826,7 +1829,6 @@ static cl_int l_build_from_source_in_dir(acl_device_program_info_t *dev_prog,
       }
       if (!cmdfp || (cmd[i].length() != bytes_written)) {
         if (debug_mode > 0) {
-          printf(" cmdfp %p\n", cmdfp);
           printf(" cmdlen %d  bw %d\n", (int)cmd[i].length(),
                  (int)bytes_written);
         }

--- a/src/acl_program.cpp
+++ b/src/acl_program.cpp
@@ -142,8 +142,7 @@ CL_API_ENTRY cl_int CL_API_CALL clReleaseProgramIntelFPGA(cl_program program) {
       if (program->device[i]->last_bin != nullptr)
         program->device[i]->last_bin->unload_content();
     }
-    if (program)
-      l_free_program(program);
+    l_free_program(program);
   }
   return CL_SUCCESS;
 }


### PR DESCRIPTION
# Fixed coverity in acl_program.cpp: Dead default in switch (DEADCODE)
(line 256) Default branch never reached since `switch (pass)` only has 0 and 1 as values because `pass` is defined in a for-loop (line 225)  as `< 2`.

# Fixed coverity in acl_program.cpp: Dereference before null check (REVERSE_INULL)
(line 145) Program is already dereferenced in the for-loop above to check `program->num_devices`, so the check would also pass. 

# Fixed coverity in acl_program.cpp: Use after free (USE_AFTER_FREE)
(line 1834) Coverity complains that you should not print the pointer address value if it has already been freed. Since we are not accessing what's in the pointer itself, it is safe to query about pointer address value. Therefore, instead of passing the pointer as the argument, a dereferenced pointer to that pointer is passed as an argument instead. 
