### PR TITLE
Fixed coverity in acl_globals.cpp

### DIFF
--- a/src/acl_globals.cpp
+++ b/src/acl_globals.cpp
@@ -203,7 +203,9 @@ cl_bool acl_init_from_hal_discovery(void) {
     return CL_FALSE;
   }
   // Probe the HAL for a device.
-  acl_set_hal(board_hal);
+  if (!acl_set_hal(board_hal)) {
+    return CL_FALSE;
+  }
 
   if (use_offline_only != ACL_CONTEXT_OFFLINE_ONLY) {
     acl_present_board_is_valid_value = 1;


### PR DESCRIPTION
# Fixed coverity in acl_globals.cpp: Unchecked return value (CHECKED_RETURN)
Coverity was complaining that `acl_set_hal` function return value was not checked. The function `acl_init_from_hal_discovery` that contains the `acl_set_hal` issue is initializing the HAL and load the builtin system definition.  `acl_set_hal` returns `0` if HAL is unvalid. Since the HAL is normally just set once on startup and then not changed, I believe that if the HAL is not valid, it should be considered as uninitialized since we cannot fetch the correct builtin system definition.