### PR TITLE
workflows: only run single instance of docker prune at a time

### DIFF
--- a/.github/workflows/container-prune.yml
+++ b/.github/workflows/container-prune.yml
@@ -6,6 +6,9 @@
 # https://docs.docker.com/config/pruning/
 name: prune container images on self-hosted runners
 
+# docker permits only a single prune operation at a time
+concurrency: container-prune
+
 on:
   push:
     branches:


### PR DESCRIPTION
This resolves a workflow failure when two jobs are queued while the runnner is offline and start concurrently when it goes online again.

Signed-off-by: Peter Colberg <peter.colberg@intel.com>