### PR TITLE
pkg_editor: fix build when zlib is not available

### DIFF
--- a/lib/pkg_editor/src/pkg_editor.c
+++ b/lib/pkg_editor/src/pkg_editor.c
@@ -39,7 +39,9 @@
 #endif
 
 #include "pkg_editor/pkg_editor.h"
+#if USE_ZLIB
 #include "zlib.h"
+#endif
 
 typedef struct acl_pkg_file {
   const char *fname;


### PR DESCRIPTION
This amends https://github.com/intel/fpga-runtime-for-opencl/pull/248