### PR TITLE
Fix Coverity issues in `acl_kernel_test.cpp`

### DIFF
--- a/test/acl_kernel_test.cpp
+++ b/test/acl_kernel_test.cpp
@@ -2103,7 +2103,7 @@ TEST(acl_kernel, local_arg_alloc) {
   for (size_t itry = 0; itry < sizeof(local_sizes) / sizeof(local_sizes[0]);
        ++itry) {
     const int second_local_size = 1; // doesn't matter, as long as it's positive
-    acl_print_debug_msg("%d ", local_sizes[itry]);
+    acl_print_debug_msg("%zu ", local_sizes[itry]);
     CHECK_EQUAL(CL_SUCCESS, clSetKernelArg(kernel, 1, local_sizes[itry], 0));
     CHECK_EQUAL(CL_SUCCESS, clSetKernelArg(kernel, 2, second_local_size, 0));
 
@@ -2134,7 +2134,7 @@ TEST(acl_kernel, local_arg_alloc) {
       }
       CHECK_EQUAL(0, arg[0]);
       CHECK_EQUAL(0, arg[3]);
-      acl_print_debug_msg(" local args ( %d, %d ) -> %x, %x -> delta %d \n",
+      acl_print_debug_msg(" local args ( %zu, %d ) -> %x, %x -> delta %d \n",
                           local_sizes[itry], second_local_size, arg[1], arg[2],
                           arg[2] - arg[1]);
       CHECK(arg[1] != arg[2]);


### PR DESCRIPTION
Fixes:
```
test/acl_kernel_test.cpp:2106:32:
  Type: Invalid type in argument to printf format specifier (PRINTF_ARGS)

test/acl_kernel_test.cpp:2106:32:
  invalid_type: Argument "local_sizes[itry]" to format specifier "%d" was expected to have type "int" but has type "unsigned long".
src/acl_hal.cpp:123:3:
  path: Condition "debug_mode > 0", taking true branch.
src/acl_hal.cpp:126:5:
  printf_function: Calling "vprintf" which uses a "printf"-style format string. [Note: The source code implementation of the function has been overridden by a builtin model.]

test/acl_kernel_test.cpp:2138:27:
  Type: Invalid type in argument to printf format specifier (PRINTF_ARGS)

test/acl_kernel_test.cpp:2138:27:
  invalid_type: Argument "local_sizes[itry]" to format specifier "%d" was expected to have type "int" but has type "unsigned long".
src/acl_hal.cpp:123:3:
  path: Condition "debug_mode > 0", taking true branch.
src/acl_hal.cpp:126:5:
  printf_function: Calling "vprintf" which uses a "printf"-style format string. [Note: The source code implementation of the function has been overridden by a builtin model.]
```