### PR TITLE
Fix Coverity issues in `acl_profiler_test.cpp`

### DIFF
--- a/test/acl_profiler_test.cpp
+++ b/test/acl_profiler_test.cpp
@@ -430,7 +430,7 @@ TEST(acl_profile, op_type_checks) {
 TEST(acl_profile, valid_checks) {
   acl_device_op_t op;
   op.info.type = ACL_DEVICE_OP_KERNEL;
-
+  memset(op.timestamp, 0, sizeof(op.timestamp));
   op.info.event = 0;
   ACL_LOCKED(CHECK(!acl_event_is_valid(op.info.event)));
   ACL_LOCKED(CHECK(!acl_process_profiler_scan_chain(&op)));
@@ -611,7 +611,8 @@ MT_TEST_GROUP(acl_no_profile) {
   enum { MAX_DEVICES = 100, m_num_devices_in_context = 3 };
   void setup() {
     if (threadNum() == 0) {
-      remove(PROFILE_MON);
+      // Remove PROFILE_MON if it exists.
+      (void)remove(PROFILE_MON);
 
       acl_test_setup_generic_system();
 


### PR DESCRIPTION
There were two issues:
- A file deletion operation's return value was not being checked. I ignored the return value.
- An array in a struct was not being initialized, even though it is updated by the HAL only.

Fixes:
```
test/acl_profiler_test.cpp:614:7:
  Type: Unchecked return value from library (CHECKED_RETURN)

test/acl_profiler_test.cpp:613:5: Unchecked call to function
  1. path: Condition "MtUtest::threadNum() == 0", taking true branch.
test/acl_profiler_test.cpp:614:7:
  2. check_return: Calling "remove("profile.mon")" without checking return value. This library function may fail and return an error code.

test/acl_profiler_test.cpp:436:3:
  Type: Uninitialized scalar variable (UNINIT)

test/acl_profiler_test.cpp:431:3:
  1. var_decl: Declaring variable "op".
test/acl_profiler_test.cpp:435:3:
  2. path: Condition "!acl_event_is_valid(op.info.event)", taking true branch.
test/acl_profiler_test.cpp:435:3:
  3. path: Condition "!Utest::getCurrent()->assertTrue(!acl_event_is_valid(op.info.event), "!acl_event_is_valid(op.info.event)", "../../test/acl_profiler_test.cpp", 435)", taking false branch.
test/acl_profiler_test.cpp:436:3:
  4. uninit_use_in_call: Using uninitialized element of array "op.timestamp" when calling "acl_process_profiler_scan_chain".
src/acl_profiler.cpp:734:3:
  4.1. path: Condition "!profile_enable", taking false branch.
src/acl_profiler.cpp:747:3:
  4.2. path: Condition "!acl_is_inside_sig()", taking true branch.
src/acl_profiler.cpp:758:3:
  4.3. path: Condition "!acl_is_inside_sig()", taking true branch.
src/acl_profiler.cpp:761:5:
  4.4. path: Condition "!acl_event_is_valid(event)", taking false branch.
src/acl_profiler.cpp:766:5:
  4.5. path: Condition "!acl_command_queue_is_valid(event->command_queue)", taking false branch.
src/acl_profiler.cpp:771:5:
  4.6. path: Condition "acl_event_is_done(event)", taking false branch.
src/acl_profiler.cpp:781:3:
  4.7. path: Condition "!device_id", taking false branch.
src/acl_profiler.cpp:789:3:
  4.8. path: Condition "op_type != ACL_DEVICE_OP_KERNEL", taking true branch.
src/acl_profiler.cpp:789:3:
  4.9. path: Condition "profile_timer_on != 1", taking false branch.
src/acl_profiler.cpp:794:3:
  4.10. path: Condition "op_type == ACL_DEVICE_OP_KERNEL", taking false branch.
src/acl_profiler.cpp:823:10:
  4.11. path: Condition "profile_timer_on != 1", taking false branch.
src/acl_profiler.cpp:827:10:
  4.12. path: Condition "op_type == ACL_DEVICE_OP_MEM_TRANSFER_COPY", taking true branch.
src/acl_profiler.cpp:829:3:
  4.13. path: Falling through to end of if statement.
src/acl_profiler.cpp:849:3:
  4.14. read_value: Reading value "op->timestamp[0]".
src/acl_profiler.cpp:850:3:
  4.15. path: Condition "end_time == 0", taking true branch.
src/acl_profiler.cpp:864:3:
  4.16. path: Condition "op->timestamp[0] != 0", taking true branch.

test/acl_profiler_test.cpp:442:3:
  Type: Uninitialized scalar variable (UNINIT)

test/acl_profiler_test.cpp:431:3:
  1. var_decl: Declaring variable "op".
test/acl_profiler_test.cpp:435:3:
  2. path: Condition "!acl_event_is_valid(op.info.event)", taking true branch.
test/acl_profiler_test.cpp:435:3:
  3. path: Condition "!Utest::getCurrent()->assertTrue(!acl_event_is_valid(op.info.event), "!acl_event_is_valid(op.info.event)", "../../test/acl_profiler_test.cpp", 435)", taking false branch.
test/acl_profiler_test.cpp:436:3:
  4. path: Condition "!acl_process_profiler_scan_chain(&op)", taking true branch.
test/acl_profiler_test.cpp:436:3:
  5. path: Condition "!Utest::getCurrent()->assertTrue(!acl_process_profiler_scan_chain(&op), "!acl_process_profiler_scan_chain(&op)", "../../test/acl_profiler_test.cpp", 436)", taking false branch.
test/acl_profiler_test.cpp:441:3:
  6. path: Condition "!acl_event_is_valid(op.info.event)", taking true branch.
test/acl_profiler_test.cpp:441:3:
  7. path: Condition "!Utest::getCurrent()->assertTrue(!acl_event_is_valid(op.info.event), "!acl_event_is_valid(op.info.event)", "../../test/acl_profiler_test.cpp", 441)", taking false branch.
test/acl_profiler_test.cpp:442:3:
  8. uninit_use_in_call: Using uninitialized element of array "op.timestamp" when calling "acl_process_profiler_scan_chain".
src/acl_profiler.cpp:734:3:
  8.1. path: Condition "!profile_enable", taking false branch.
src/acl_profiler.cpp:747:3:
  8.2. path: Condition "!acl_is_inside_sig()", taking true branch.
src/acl_profiler.cpp:758:3:
  8.3. path: Condition "!acl_is_inside_sig()", taking true branch.
src/acl_profiler.cpp:761:5:
  8.4. path: Condition "!acl_event_is_valid(event)", taking false branch.
src/acl_profiler.cpp:766:5:
  8.5. path: Condition "!acl_command_queue_is_valid(event->command_queue)", taking false branch.
src/acl_profiler.cpp:771:5:
  8.6. path: Condition "acl_event_is_done(event)", taking false branch.
src/acl_profiler.cpp:781:3:
  8.7. path: Condition "!device_id", taking false branch.
src/acl_profiler.cpp:789:3:
  8.8. path: Condition "op_type != ACL_DEVICE_OP_KERNEL", taking true branch.
src/acl_profiler.cpp:789:3:
  8.9. path: Condition "profile_timer_on != 1", taking false branch.
src/acl_profiler.cpp:794:3:
  8.10. path: Condition "op_type == ACL_DEVICE_OP_KERNEL", taking false branch.
src/acl_profiler.cpp:823:10:
  8.11. path: Condition "profile_timer_on != 1", taking false branch.
src/acl_profiler.cpp:827:10:
  8.12. path: Condition "op_type == ACL_DEVICE_OP_MEM_TRANSFER_COPY", taking true branch.
src/acl_profiler.cpp:829:3:
  8.13. path: Falling through to end of if statement.
src/acl_profiler.cpp:849:3:
  8.14. read_value: Reading value "op->timestamp[0]".
src/acl_profiler.cpp:850:3:
  8.15. path: Condition "end_time == 0", taking true branch.
src/acl_profiler.cpp:864:3:
  8.16. path: Condition "op->timestamp[0] != 0", taking true branch.
```