### PR TITLE
Device global copy kernel implementation

### DIFF
--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -2384,6 +2384,66 @@ clCreateBufferWithPropertiesINTEL_fn)(
     void *       host_ptr,
     cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
+/**********************************
+* cl_intel_global_variable_access *
+***********************************/
+
+#define CL_COMMAND_READ_GLOBAL_VARIABLE_INTEL   0x418E
+#define CL_COMMAND_WRITE_GLOBAL_VARIABLE_INTEL  0x418F
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReadGlobalVariableINTEL(
+    cl_command_queue command_queue,
+    cl_program program,
+    const char* name,
+    cl_bool blocking_read,
+    size_t size,
+    size_t offset,
+    void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+    
+
+typedef CL_API_ENTRY cl_int (CL_API_CALL *
+clEnqueueReadGlobalVariableINTEL_fn)(
+    cl_command_queue command_queue,
+    cl_program program,
+    const char* name,
+    cl_bool blocking_read,
+    size_t size,
+    size_t offset,
+    const void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueWriteGlobalVariableINTEL(
+    cl_command_queue command_queue,
+    cl_program program,
+    const char* name,
+    cl_bool blocking_write,
+    size_t size,
+    size_t offset,
+    const void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+
+typedef CL_API_ENTRY cl_int (CL_API_CALL *
+clEnqueueWriteGlobalVariableINTEL_fn)(
+    cl_command_queue command_queue,
+    cl_program program,
+    const char* name,
+    cl_bool blocking_read,
+    size_t size,
+    size_t offset,
+    void* ptr,
+    cl_uint num_events_in_wait_list,
+    const cl_event* event_wait_list,
+    cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+
 /******************************************
 * cl_intel_mem_channel_property extension *
 *******************************************/

--- a/include/acl.h
+++ b/include/acl.h
@@ -248,8 +248,6 @@ typedef struct {
 
   bool streaming_control_info_available;
   acl_streaming_kernel_control_info streaming_control_info;
-  unsigned int device_global_address; /* Address of kernel's device global*/
-  unsigned int device_global_size; /* Size of address space of device global used by this kernel*/
 } acl_accel_def_t;
 
 /* An ACL system definition.
@@ -500,6 +498,7 @@ typedef class acl_device_program_info_t *acl_device_program_info;
  */
 #define ACL_MEM_CAPABILITY_P2P (1 << 3)
 
+<<<<<<< HEAD
 // Enum values here need to match the SPIRV spec for device global in
 // https://github.com/intel/llvm/blob/44c6437684d64aba82d5a3de0e4bbe21d2b1f7ce/sycl/doc/design/spirv-extensions/SPV_INTEL_global_variable_decorations.asciidoc
 // ACL_DEVICE_GLOBAL_HOST_ACCESS_TYPE_COUNT is used for validation
@@ -534,6 +533,13 @@ struct acl_device_global_mem_def_t {
   acl_device_global_init_mode_t init_mode;
   bool implement_in_csr;
 };
+=======
+typedef struct acl_device_global_mem_def_t {
+  std::string name;
+  unsigned int address;
+  unsigned int size;
+} acl_device_global_mem_def_t;
+>>>>>>> c767c31... Add device global in device autodiscovery definition
 
 // Part of acl_device_def_t where members are populated from the information
 // in the autodiscovery string. This will get updated every time the device
@@ -554,11 +560,18 @@ typedef struct acl_device_def_autodiscovery_t {
 
   std::vector<acl_hostpipe_info_t> acl_hostpipe_info;
 
+<<<<<<< HEAD
   // Device global definition.
   std::unordered_map<std::string, acl_device_global_mem_def_t>
       device_global_mem_defs;
   bool cra_ring_root_exist =
       true; // Set the default value to true for backwards compatibility flows.
+=======
+  // device global definition
+  unsigned int num_device_global;
+  std::unordered_map<std::string, acl_device_global_mem_def_t>
+      device_global_mem_defs;
+>>>>>>> c767c31... Add device global in device autodiscovery definition
 } acl_device_def_autodiscovery_t;
 
 typedef struct acl_device_def_t {

--- a/include/acl.h
+++ b/include/acl.h
@@ -248,6 +248,8 @@ typedef struct {
 
   bool streaming_control_info_available;
   acl_streaming_kernel_control_info streaming_control_info;
+  unsigned int device_global_address; /* Address of kernel's device global*/
+  unsigned int device_global_size; /* Size of address space of device global used by this kernel*/
 } acl_accel_def_t;
 
 /* An ACL system definition.

--- a/include/acl.h
+++ b/include/acl.h
@@ -569,6 +569,7 @@ typedef struct acl_device_def_autodiscovery_t {
 =======
   // device global definition
   unsigned int num_device_global;
+  // std::vector<acl_device_global_mem_def_t> device_global_mem_defs;
   std::unordered_map<std::string, acl_device_global_mem_def_t>
       device_global_mem_defs;
 >>>>>>> c767c31... Add device global in device autodiscovery definition

--- a/include/acl_kernel.h
+++ b/include/acl_kernel.h
@@ -61,6 +61,10 @@ int acl_kernel_has_unmapped_subbuffers(acl_mem_migrate_t *mem_migration);
 // currently loaded program.
 bool acl_device_has_reprogram_device_globals(cl_device_id device);
 
+cl_int set_kernel_arg_mem_pointer_without_checks(cl_kernel kernel,
+                                                 cl_uint arg_index,
+                                                 void *arg_value);
+
 #if defined(__cplusplus)
 } /* extern "C" */
 #endif

--- a/include/acl_mem.h
+++ b/include/acl_mem.h
@@ -97,6 +97,10 @@ void CL_CALLBACK acl_dev_global_cleanup(cl_event event,
                                         cl_int event_command_exec_status,
                                         void *callback_data);
 
+cl_int acl_extract_device_global_address(cl_kernel kernel,
+                                         const char *dev_global_name,
+                                         unsigned int *ret_addr);
+
 #ifdef __GNUC__
 #pragma GCC visibility pop
 #endif

--- a/include/acl_mem.h
+++ b/include/acl_mem.h
@@ -93,6 +93,10 @@ cl_bool acl_is_sub_or_parent_buffer(cl_mem mem);
 void CL_CALLBACK acl_free_allocation_after_event_completion(
     cl_event event, cl_int event_command_exec_status, void *callback_data);
 
+void CL_CALLBACK acl_dev_global_cleanup(cl_event event,
+                                        cl_int event_command_exec_status,
+                                        void *callback_data);
+
 #ifdef __GNUC__
 #pragma GCC visibility pop
 #endif

--- a/src/acl_auto_configure.cpp
+++ b/src/acl_auto_configure.cpp
@@ -96,6 +96,7 @@ static bool read_uint_counters(const std::string &str,
     UNREFERENCED_PARAMETER(e);
     return false;
   }
+
   return true;
 }
 

--- a/src/acl_icd_dispatch.cpp
+++ b/src/acl_icd_dispatch.cpp
@@ -50,6 +50,8 @@ clGetExtensionFunctionAddressIntelFPGA(const char *func_name) {
   ADDFUNCTIONLOOKUP(clResetKernelsIntelFPGA);
   ADDFUNCTIONLOOKUP(clSetBoardLibraryIntelFPGA);
   ADDFUNCTIONLOOKUP(clCreateBufferWithPropertiesINTEL);
+  ADDFUNCTIONLOOKUP(clEnqueueReadGlobalVariableINTEL);
+  ADDFUNCTIONLOOKUP(clEnqueueWriteGlobalVariableINTEL);
 
 // USM APIs are not currently supported on 32bit devices
 #ifndef __arm__

--- a/src/acl_kernel.cpp
+++ b/src/acl_kernel.cpp
@@ -831,6 +831,41 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgSVMPointer(
   return clSetKernelArgSVMPointerIntelFPGA(kernel, arg_index, arg_value);
 }
 
+cl_int set_kernel_arg_mem_pointer_without_checks(cl_kernel kernel,
+                                                 cl_uint arg_index,
+                                                 void *arg_value) {
+  acl_lock();
+  if (!acl_kernel_is_valid(kernel)) {
+    UNLOCK_RETURN(CL_INVALID_KERNEL);
+  }
+
+  cl_context context = kernel->program->context;
+
+  if (arg_index >= kernel->accel_def->iface.args.size()) {
+    UNLOCK_ERR_RET(CL_INVALID_ARG_INDEX, context,
+                   "Argument index is too large");
+  }
+
+  // Determine where to write the value.
+  size_t start_idx = 0;
+  size_t iface_arg_size = 0;
+  l_get_arg_offset_and_size(kernel, arg_index, &start_idx, &iface_arg_size);
+  safe_memcpy(&(kernel->arg_value[start_idx]), &arg_value, iface_arg_size,
+              kernel->arg_value_size - start_idx, iface_arg_size);
+  kernel->arg_is_svm[arg_index] = CL_FALSE;
+  kernel->arg_is_ptr[arg_index] = CL_TRUE;
+
+  kernel->arg_defined[arg_index] = 1;
+
+  // double vector size if size < arg_index
+  while (kernel->ptr_arg_vector.size() <= arg_index) {
+    kernel->ptr_arg_vector.resize(kernel->ptr_arg_vector.size() * 2);
+  }
+  kernel->ptr_arg_vector[arg_index] = arg_value;
+
+  UNLOCK_RETURN(CL_SUCCESS);
+}
+
 ACL_EXPORT
 CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgMemPointerINTEL(
     cl_kernel kernel, cl_uint arg_index, const void *arg_value) {

--- a/src/acl_kernel.cpp
+++ b/src/acl_kernel.cpp
@@ -831,6 +831,22 @@ CL_API_ENTRY cl_int CL_API_CALL clSetKernelArgSVMPointer(
   return clSetKernelArgSVMPointerIntelFPGA(kernel, arg_index, arg_value);
 }
 
+/**
+ * Set any provided void pointer as kernel arguments
+ *
+ * It is assumed that the provided pointer is a valid device address,
+ * or device global address that kernel can use to point to right address space.
+ *
+ * It is the same as `clSetKernelArgMemPointerINTEL` except the validity checks
+ * are removed. This is because the user provided pointer may not always be usm
+ * pointer, therefore will not belong to the context (as they are checked in
+ * clSetKernelArgMemPointerINTEL)
+ *
+ * @param kernel the kernel that accept the pointer arg
+ * @param arg_index which kernel argument accept the value
+ * @param arg_value the pointer to desired address space
+ * @return status code, CL_SUCCESS if all operations are successful.
+ */
 cl_int set_kernel_arg_mem_pointer_without_checks(cl_kernel kernel,
                                                  cl_uint arg_index,
                                                  void *arg_value) {

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -424,10 +424,12 @@ CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
   }
 
   // dev_addr_t dev_global_address =
-  uintptr_t dev_global_address = kernel->accel_def->device_global_address;
-  assert(kernel->accel_def->device_global_address == 4096); // TODO: remove when merging
-  // uintptr_t dev_global_address = 0x4000000;
-  // TODO: add checks for whether the copy will be out of bound for device global
+  // uintptr_t dev_global_address =
+  // kernel->dev_bin->get_devdef().autodiscovery_def.device_global_mem_defs[name];
+  // uintptr_t dev_global_address = kernel->accel_def->device_global_address;
+  uintptr_t dev_global_address = 0x4000000;
+  // TODO: add checks for whether the copy will be out of bound for device
+  // global
   void *dev_global_ptr =
       (void *)(dev_global_address + offset * 8); // 1 unit of offset is 8 bits
   status = set_kernel_arg_mem_pointer_without_checks(kernel, 0, dev_global_ptr);

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -599,6 +599,7 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
     }
     callback_data[0] = (void *)(src_dev_ptr);
     callback_data[1] = (void *)(kernel);
+    callback_data[2] = NULL;
     clSetEventCallback(*event, CL_COMPLETE, acl_dev_global_cleanup,
                        (void *)callback_data);
   }

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -448,6 +448,7 @@ CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
   if (status != CL_SUCCESS) {
     return status;
   }
+  assert(kernel);
 
   // Look up device global address with use provided name
   unsigned int device_global_addr_num = 0;
@@ -575,6 +576,7 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
   if (status != CL_SUCCESS) {
     return status;
   }
+  assert(kernel);
 
   // Allocate a temporary device usm pointer to hold user data
   // This is done to minimize kernel area, as device to device memory

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -409,8 +409,32 @@ int acl_bind_buffer_to_device(cl_device_id device, cl_mem mem) {
   return 1;
 }
 
+/**
+ * Read <size> bytes of data from device global
+ *
+ * This function extract the device global address with given name, create
+ * kernel from the given program, create temporary device usm pointer to hold
+ * data that will be copied from device global. Launch the copy kernel with
+ * correct pointers set as src and destination, then enqueue a memory copy
+ * operation that depend on copy kernel to copy from temporary device usm
+ * pointer into user provided host pointer. Then register a callback to release
+ * the necessary events, kernels, memories.
+ *
+ * @param command_queue the queue system this copy kernel will belong
+ * @param program contains copy kernel
+ * @param name name of device global, used to look up for device global address
+ * in autodiscovery string
+ * @param blocking_read whether the operation is blocking or not
+ * @param size number of bytes to read / write
+ * @param offset offset from the extracted address of device global
+ * @param ptr pointer that will hold the data copied from device global
+ * @param num_events_in_wait_list number of event that copy kernel depend on
+ * @param event_wait_list events that copy kernel depend on
+ * @param event the info about the execution of copy kernel will be stored in
+ * the event
+ * @return status code, CL_SUCCESS if all operations are successful.
+ */
 ACL_EXPORT
-// CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL() {
 CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
     cl_command_queue command_queue, cl_program program, const char *name,
     cl_bool blocking_read, size_t size, size_t offset, void *ptr,
@@ -418,27 +442,36 @@ CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
     cl_event *event) {
   cl_int status;
 
-  cl_kernel kernel = clCreateKernelIntelFPGA(program, name, &status);
+  // Get copy kernel from the program
+  cl_kernel kernel =
+      clCreateKernelIntelFPGA(program, "copy_device_global", &status);
   if (status != CL_SUCCESS) {
     return status;
   }
 
-  // dev_addr_t dev_global_address =
-  // uintptr_t dev_global_address =
-  // kernel->dev_bin->get_devdef().autodiscovery_def.device_global_mem_defs[name];
-  // uintptr_t dev_global_address = kernel->accel_def->device_global_address;
-  uintptr_t dev_global_address = 0x4000000;
-  // TODO: add checks for whether the copy will be out of bound for device
-  // global
+  // Look up device global address with use provided name
+  unsigned int device_global_addr_num = 0;
+  status =
+      acl_extract_device_global_address(kernel, name, &device_global_addr_num);
+  if (status != CL_SUCCESS)
+    return status;
+  uintptr_t dev_global_address = device_global_addr_num;
+
+  // Calculate the offset from the device global address, offset is in byte unit
   void *dev_global_ptr =
       (void *)(dev_global_address + offset * 8); // 1 unit of offset is 8 bits
+  // TODO: add checks for whether the copy will be out of bound for device
+  // global
+
+  // Set the device global pointer as the kernel destination args
   status = set_kernel_arg_mem_pointer_without_checks(kernel, 0, dev_global_ptr);
   // status = clSetKernelArgMemPointerINTEL(kernel, 1, dev_global_ptr);
   if (status != CL_SUCCESS) {
     return status;
   }
 
-  // Copy device global memory to temporary device usm pointer first
+  // Copy device global memory to temporary device usm pointer first to minimize
+  // area cost
   void *tmp_dev_ptr = clDeviceMemAllocINTEL(
       command_queue->context, command_queue->device, NULL, size, 1, &status);
   if (status != CL_SUCCESS) {
@@ -453,24 +486,22 @@ CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
     return status;
   }
 
-  // Set size kernel arg
+  // Propagate size information to kernel
   status = clSetKernelArg(kernel, 2, sizeof(size_t), (const void *)(&size));
   if (status != CL_SUCCESS) {
     return status;
   }
 
+  // Enqueue copy kernel execution
   cl_event tmp_event = 0;
   status = clEnqueueTask(command_queue, kernel, num_events_in_wait_list,
                          event_wait_list, &tmp_event);
   if (status != CL_SUCCESS) {
     return status;
   }
-  std::cerr << tmp_event->cmd.info.ndrange_kernel.invocation_wrapper->image
-                   ->activation_id
-            << std::endl;
 
-  // copy from the temporary device memory into user provided pointer
-  std::cerr << "read: copy from tmp dev pointer to source pointer" << std::endl;
+  // Copy from the temporary device memory into user provided host pointer
+  // give this event back to user, not the copy kernel one
   status = clEnqueueMemcpyINTEL(command_queue, blocking_read, ptr, tmp_dev_ptr,
                                 size, 1, &tmp_event, event);
   if (status != CL_SUCCESS) {
@@ -478,6 +509,7 @@ CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
   }
 
   if (blocking_read) {
+    // If blocking, first wait for event to finish, then clean up the resources.
     status = clReleaseEvent(tmp_event);
     if (status != CL_SUCCESS) {
       return status;
@@ -506,6 +538,29 @@ CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
   return CL_SUCCESS;
 }
 
+/**
+ * Write <size> bytes of data from user provided host pointer into device global
+ *
+ * This function extract the device global address with given name, create
+ * kernel from the given program, create temporary device usm pointer to hold
+ * user provided data through usm copy operation. Launch the copy kernel with
+ * correct pointers set as src and destination. Then register a callback to
+ * release the necessary events, kernels, memories.
+ *
+ * @param command_queue the queue system this copy kernel will belong
+ * @param program contains copy kernel
+ * @param name name of device global, used to look up for device global address
+ * in autodiscovery string
+ * @param blocking_write whether the operation is blocking or not
+ * @param size number of bytes to read / write
+ * @param offset offset from the extracted address of device global
+ * @param ptr pointer that will hold the data copied from device global
+ * @param num_events_in_wait_list number of event that copy kernel depend on
+ * @param event_wait_list events that copy kernel depend on
+ * @param event the info about the execution of copy kernel will be stored in
+ * the event
+ * @return status code, CL_SUCCESS if all operations are successful.
+ */
 ACL_EXPORT
 CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
     cl_command_queue command_queue, cl_program program, const char *name,
@@ -514,63 +569,64 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
     cl_event *event) {
   cl_int status;
 
-  cl_kernel kernel = clCreateKernelIntelFPGA(program, name, &status);
+  // Get copy kernel from the program
+  cl_kernel kernel =
+      clCreateKernelIntelFPGA(program, "copy_device_global", &status);
   if (status != CL_SUCCESS) {
     return status;
   }
 
-  // do we support ptr being a buffer instead of usm pointer? it seems to be the
-  // case on spec (only usm host pointer) Given kernel arg must be a deivce usm
-  // pointer: When ptr is a host/shared usm pointer, this function is expected
-  // to copy it to device first? yes (currently discussing whether kernel arg
-  // accept host usm instead)
+  // Allocate a temporary device usm pointer to hold user data
+  // This is done to minimize kernel area, as device to device memory
+  // interconnect occupies least amount of memory
   void *src_dev_ptr = clDeviceMemAllocINTEL(
       command_queue->context, command_queue->device, NULL, size, 1, &status);
   if (status != CL_SUCCESS) {
     return status;
   }
 
-  // This copy operation have to be blocking
-  // cl_event to_dev_event = 0;
+  // Copy from user provide host pointer to temporary device usm pointer
   status = clEnqueueMemcpyINTEL(command_queue, CL_TRUE, src_dev_ptr, ptr, size,
                                 0, NULL, NULL);
   if (status != CL_SUCCESS) {
     return status;
   }
 
-  // if (to_dev_event->execution_status != CL_COMPLETE) {
-  //   return CL_INVALID_OPERATION;
-  // }
-
+  // Set the source of copy (in kernel arg) as the temporary device usm pointer
   status = clSetKernelArgMemPointerINTEL(kernel, 0, src_dev_ptr);
   if (status != CL_SUCCESS) {
     return status;
   }
-  // should kernel header contain offset or not? no
-  // offset is always byte offset? yes
-  // Assuming below returns same thing as `clDeviceMemAllocINTEL`, where exactly
-  // is dev global ptr being read from? What format is the read dev global, is
-  // it a pointer just like the return value of `clDeviceMemAllocINTEL` or is it
-  // something else? (its an unsigned value indicating address)
-  // TODO: When passing dev global pointer directly to
-  // clSetKernelArgMemPointerINTEL, make sure REMOVE_VALID_CHECKS is defined.
-  // Otherwise this ptr is not existing in context -> cause checks to fail
-  // TODO: get dev_global_address from autodiscovery instead later
-  // dev_addr_t dev_global_address =
-  // kernel->dev_bin->get_devdef().autodiscovery_def.?
-  uintptr_t dev_global_address = 0x4000000;
+
+  // Look up device global address with use provided name
+  unsigned int device_global_addr_num = 0;
+  status =
+      acl_extract_device_global_address(kernel, name, &device_global_addr_num);
+  if (status != CL_SUCCESS)
+    return status;
+  uintptr_t dev_global_address = device_global_addr_num;
+
+  // TODO: remove the following checks, as it only works for unit test
+  assert(((unsigned int)dev_global_address) == 0x1024);
+  // Calculate the offset from the device global address, offset is in byte unit
   void *dev_global_ptr =
       (void *)(dev_global_address + offset * 8); // 1 unit of offset is 8 bits
+  // TODO: add checks for whether the copy will be out of bound for device
+  // global
+
+  // Set the device global pointer as the kernel destination args
   status = set_kernel_arg_mem_pointer_without_checks(kernel, 1, dev_global_ptr);
-  // status = clSetKernelArgMemPointerINTEL(kernel, 1, dev_global_ptr);
   if (status != CL_SUCCESS) {
     return status;
   }
+
+  // Propagate size information to kernel
   status = clSetKernelArg(kernel, 2, sizeof(size_t), (const void *)(&size));
   if (status != CL_SUCCESS) {
     return status;
   }
 
+  // Enqueue kernel execution
   status = clEnqueueTask(command_queue, kernel, num_events_in_wait_list,
                          event_wait_list, event);
   if (status != CL_SUCCESS) {
@@ -583,6 +639,7 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
   acl_unlock();
 
   if (blocking_write) {
+    // If blocking, first wait for event to finish, then clean up the resources.
     status = clWaitForEvents(1, event);
     if (status == CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST) {
       return status;
@@ -596,7 +653,7 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
       return status;
     }
   } else {
-    // Clean up resources after event finishes
+    // Otherwise, clean up resources after event finishes
     void **callback_data = (void **)acl_malloc(sizeof(void *) * 3);
     if (!callback_data) {
       return CL_OUT_OF_HOST_MEMORY;
@@ -611,6 +668,53 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
   return CL_SUCCESS;
 }
 
+/**
+ * Look up device global address in autodiscovery def using user provided name
+ *
+ * @param kernel the copy kernel
+ * @param dev_global_name name of device global to query
+ * @param ret_addr hold the resulting address of device global
+ * @return status code, CL_SUCCESS if all operations are successful.
+ */
+cl_int acl_extract_device_global_address(cl_kernel kernel,
+                                         const char *dev_global_name,
+                                         unsigned int *ret_addr) {
+  acl_lock();
+  // In full system flow, the autodiscovery string is available through kernel's
+  // dev_bin, however it is not in unit testing framework Thus, try to find
+  // device global definition first on kernel's device bin, if not found then
+  // try on acl_present_board_def(), which is set in unit test setup steps.
+  std::unordered_map<std::string, acl_device_global_mem_def_t> dev_global_map =
+      kernel->dev_bin->get_devdef().autodiscovery_def.device_global_mem_defs;
+  std::unordered_map<std::string, acl_device_global_mem_def_t>::const_iterator
+      dev_global = dev_global_map.find(dev_global_name);
+  if (dev_global != dev_global_map.end()) {
+    *ret_addr = dev_global->second.address;
+    UNLOCK_RETURN(CL_SUCCESS);
+  }
+  // Device global name not found in kernel dev_bin, try to find in the sysdef
+  // setup by unit tests
+  dev_global_map = acl_present_board_def()
+                       ->device[0]
+                       .autodiscovery_def.device_global_mem_defs;
+  dev_global = dev_global_map.find(dev_global_name);
+  if (dev_global != dev_global_map.end()) {
+    *ret_addr = dev_global->second.address;
+    UNLOCK_RETURN(CL_SUCCESS);
+  }
+  UNLOCK_RETURN(CL_INVALID_VALUE);
+}
+
+/**
+ * Callback function that executes after copy event finishes
+ *
+ * Main responsible for free heap memories, device memories
+ *
+ * @param event the event that this callback is registered on
+ * @param event_command_exec_status the status of of event (queue, complete etc)
+ * @param callback_data hold the resources that need to be released
+ * @return nothing
+ */
 void CL_CALLBACK acl_dev_global_cleanup(cl_event event,
                                         cl_int event_command_exec_status,
                                         void *callback_data) {
@@ -623,12 +727,15 @@ void CL_CALLBACK acl_dev_global_cleanup(cl_event event,
   event = event;
   acl_lock();
   if (callback_ptrs[0]) {
+    // Free intermediate device usm pointers
     clMemFreeINTEL(event->context, callback_ptrs[0]);
   }
   if (callback_ptrs[1]) {
+    // Release kernel from hep memory as its associated device memory
     clReleaseKernel(((cl_kernel)callback_ptrs[1]));
   }
   if (callback_ptrs[2]) {
+    // Release event from hep memory
     clReleaseEvent(((cl_event)callback_ptrs[2]));
   }
   acl_free(callback_data);

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -413,15 +413,93 @@ ACL_EXPORT
 // CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL() {
 CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
     cl_command_queue command_queue, cl_program program, const char *name,
-    cl_bool blocking_write, size_t size, size_t offset, void *ptr,
+    cl_bool blocking_read, size_t size, size_t offset, void *ptr,
     cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
     cl_event *event) {
+  cl_int status;
 
-  // TODO: get dev_global_ptr from autodiscovery instead later
-  // return 0;
-  return clEnqueueWriteGlobalVariableINTEL(
-      command_queue, program, name, blocking_write, size, offset, ptr,
-      num_events_in_wait_list, event_wait_list, event);
+  cl_kernel kernel = clCreateKernelIntelFPGA(program, name, &status);
+  if (status != CL_SUCCESS) {
+    return status;
+  }
+
+  // dev_addr_t dev_global_address =
+  // kernel->dev_bin->get_devdef().autodiscovery_def.?
+  uintptr_t dev_global_address = 0x4000000;
+  void *dev_global_ptr =
+      (void *)(dev_global_address + offset * 8); // 1 unit of offset is 8 bits
+  status = set_kernel_arg_mem_pointer_without_checks(kernel, 0, dev_global_ptr);
+  // status = clSetKernelArgMemPointerINTEL(kernel, 1, dev_global_ptr);
+  if (status != CL_SUCCESS) {
+    return status;
+  }
+
+  // Copy device global memory to temporary device usm pointer first
+  void *tmp_dev_ptr = clDeviceMemAllocINTEL(
+      command_queue->context, command_queue->device, NULL, size, 1, &status);
+  if (status != CL_SUCCESS) {
+    return status;
+  }
+  if (!tmp_dev_ptr) {
+    return CL_MEM_OBJECT_ALLOCATION_FAILURE;
+  }
+
+  status = clSetKernelArgMemPointerINTEL(kernel, 1, tmp_dev_ptr);
+  if (status != CL_SUCCESS) {
+    return status;
+  }
+
+  // Set size kernel arg
+  status = clSetKernelArg(kernel, 2, sizeof(size_t), (const void *)(&size));
+  if (status != CL_SUCCESS) {
+    return status;
+  }
+
+  cl_event tmp_event = 0;
+  status = clEnqueueTask(command_queue, kernel, num_events_in_wait_list,
+                         event_wait_list, &tmp_event);
+  if (status != CL_SUCCESS) {
+    return status;
+  }
+  std::cerr << tmp_event->cmd.info.ndrange_kernel.invocation_wrapper->image
+                   ->activation_id
+            << std::endl;
+
+  // copy from the temporary device memory into user provided pointer
+  std::cerr << "read: copy from tmp dev pointer to source pointer" << std::endl;
+  status = clEnqueueMemcpyINTEL(command_queue, blocking_read, ptr, tmp_dev_ptr,
+                                size, 1, &tmp_event, event);
+  if (status != CL_SUCCESS) {
+    return status;
+  }
+
+  if (blocking_read) {
+    status = clReleaseEvent(tmp_event);
+    if (status != CL_SUCCESS) {
+      return status;
+    }
+    status = clMemFreeINTEL(command_queue->context, tmp_dev_ptr);
+    if (status != CL_SUCCESS) {
+      return status;
+    }
+    status = clReleaseKernel(kernel);
+    if (status != CL_SUCCESS) {
+      return status;
+    }
+  } else {
+    // Clean up resources after event finishes
+    void **callback_data = (void **)acl_malloc(sizeof(void *) * 3);
+    if (!callback_data) {
+      return CL_OUT_OF_HOST_MEMORY;
+    }
+    callback_data[0] = (void *)(tmp_dev_ptr);
+    callback_data[1] = (void *)(kernel);
+    callback_data[2] = (void *)(tmp_event);
+    clSetEventCallback(*event, CL_COMPLETE, acl_dev_global_cleanup,
+                       (void *)callback_data);
+  }
+
+  return CL_SUCCESS;
 }
 
 ACL_EXPORT
@@ -455,6 +533,7 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
   if (status != CL_SUCCESS) {
     return status;
   }
+
   // if (to_dev_event->execution_status != CL_COMPLETE) {
   //   return CL_INVALID_OPERATION;
   // }
@@ -476,11 +555,10 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
   // dev_addr_t dev_global_address =
   // kernel->dev_bin->get_devdef().autodiscovery_def.?
   uintptr_t dev_global_address = 0x4000000;
-  void *dev_global_ptr2 =
+  void *dev_global_ptr =
       (void *)(dev_global_address + offset * 8); // 1 unit of offset is 8 bits
-  status =
-      set_kernel_arg_mem_pointer_without_checks(kernel, 1, dev_global_ptr2);
-  // status = clSetKernelArgMemPointerINTEL(kernel, 1, dev_global_ptr2);
+  status = set_kernel_arg_mem_pointer_without_checks(kernel, 1, dev_global_ptr);
+  // status = clSetKernelArgMemPointerINTEL(kernel, 1, dev_global_ptr);
   if (status != CL_SUCCESS) {
     return status;
   }
@@ -502,24 +580,54 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
 
   if (blocking_write) {
     status = clWaitForEvents(1, event);
+    if (status == CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST) {
+      return status;
+    }
+    status = clMemFreeINTEL(command_queue->context, src_dev_ptr);
+    if (status != CL_SUCCESS) {
+      return status;
+    }
+    status = clReleaseKernel(kernel);
+    if (status != CL_SUCCESS) {
+      return status;
+    }
+  } else {
+    // Clean up resources after event finishes
+    void **callback_data = (void **)acl_malloc(sizeof(void *) * 3);
+    if (!callback_data) {
+      return CL_OUT_OF_HOST_MEMORY;
+    }
+    callback_data[0] = (void *)(src_dev_ptr);
+    callback_data[1] = (void *)(kernel);
+    clSetEventCallback(*event, CL_COMPLETE, acl_dev_global_cleanup,
+                       (void *)callback_data);
   }
-
-  if (blocking_write &&
-      status == CL_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST) {
-    return status;
-  }
-
-  // Free allocated device memory
-  status = clMemFreeINTEL(command_queue->context, src_dev_ptr);
-  if (status != CL_SUCCESS) {
-    return status;
-  }
-  // status = clReleaseKernel(kernel);
-  // if (status != CL_SUCCESS) {
-  //   return status;
-  // }
 
   return CL_SUCCESS;
+}
+
+void CL_CALLBACK acl_dev_global_cleanup(cl_event event,
+                                        cl_int event_command_exec_status,
+                                        void *callback_data) {
+  void **callback_ptrs =
+      (void **)callback_data; // callback_ptrs[0] is usm device pointer
+                              // callback_ptrs[1] kernel to be released
+                              // callback_ptrs[2] temporary event to be released
+  event_command_exec_status =
+      event_command_exec_status; // Avoiding Windows warning.
+  event = event;
+  acl_lock();
+  if (callback_ptrs[0]) {
+    clMemFreeINTEL(event->context, callback_ptrs[0]);
+  }
+  if (callback_ptrs[1]) {
+    clReleaseKernel(((cl_kernel)callback_ptrs[1]));
+  }
+  if (callback_ptrs[2]) {
+    clReleaseEvent(((cl_event)callback_ptrs[2]));
+  }
+  acl_free(callback_data);
+  acl_unlock();
 }
 
 ACL_EXPORT

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -514,10 +514,10 @@ CL_API_ENTRY cl_int clEnqueueWriteGlobalVariableINTEL(
   if (status != CL_SUCCESS) {
     return status;
   }
-  status = clReleaseKernel(kernel);
-  if (status != CL_SUCCESS) {
-    return status;
-  }
+  // status = clReleaseKernel(kernel);
+  // if (status != CL_SUCCESS) {
+  //   return status;
+  // }
 
   return CL_SUCCESS;
 }

--- a/src/acl_mem.cpp
+++ b/src/acl_mem.cpp
@@ -424,8 +424,10 @@ CL_API_ENTRY cl_int clEnqueueReadGlobalVariableINTEL(
   }
 
   // dev_addr_t dev_global_address =
-  // kernel->dev_bin->get_devdef().autodiscovery_def.?
-  uintptr_t dev_global_address = 0x4000000;
+  uintptr_t dev_global_address = kernel->accel_def->device_global_address;
+  assert(kernel->accel_def->device_global_address == 4096); // TODO: remove when merging
+  // uintptr_t dev_global_address = 0x4000000;
+  // TODO: add checks for whether the copy will be out of bound for device global
   void *dev_global_ptr =
       (void *)(dev_global_address + offset * 8); // 1 unit of offset is 8 bits
   status = set_kernel_arg_mem_pointer_without_checks(kernel, 0, dev_global_ptr);

--- a/test/acl_auto_configure_test.cpp
+++ b/test/acl_auto_configure_test.cpp
@@ -269,9 +269,26 @@ TEST(auto_configure, simple) {
   CHECK_EQUAL(0,
               (int)m_device_def.autodiscovery_def.accel[0].max_work_group_size);
   CHECK_EQUAL(1, (int)m_device_def.autodiscovery_def.accel[0].is_sycl_compile);
-  CHECK_EQUAL(4096, (int)m_device_def.autodiscovery_def.accel[0].device_global_address);
-  CHECK_EQUAL(2048, (int)m_device_def.autodiscovery_def.accel[0].device_global_size);
 
+  CHECK_EQUAL(2, (int)m_device_def.autodiscovery_def.num_device_global);
+  CHECK(m_device_def.autodiscovery_def.device_global_mem_defs.find(
+            "kernel15_dev_global") !=
+        m_device_def.autodiscovery_def.device_global_mem_defs.end());
+  CHECK(m_device_def.autodiscovery_def.device_global_mem_defs.find(
+            "kernel15_dev_global2") !=
+        m_device_def.autodiscovery_def.device_global_mem_defs.end());
+  CHECK_EQUAL(4096, m_device_def.autodiscovery_def
+                        .device_global_mem_defs["kernel15_dev_global"]
+                        .address);
+  CHECK_EQUAL(2048, m_device_def.autodiscovery_def
+                        .device_global_mem_defs["kernel15_dev_global"]
+                        .size);
+  CHECK_EQUAL(2048, m_device_def.autodiscovery_def
+                        .device_global_mem_defs["kernel15_dev_global2"]
+                        .address);
+  CHECK_EQUAL(1024, m_device_def.autodiscovery_def
+                        .device_global_mem_defs["kernel15_dev_global2"]
+                        .size);
 
   // Checks for device global entry.
   CHECK_EQUAL(2, m_device_def.autodiscovery_def.device_global_mem_defs.size());

--- a/test/acl_auto_configure_test.cpp
+++ b/test/acl_auto_configure_test.cpp
@@ -269,6 +269,9 @@ TEST(auto_configure, simple) {
   CHECK_EQUAL(0,
               (int)m_device_def.autodiscovery_def.accel[0].max_work_group_size);
   CHECK_EQUAL(1, (int)m_device_def.autodiscovery_def.accel[0].is_sycl_compile);
+  CHECK_EQUAL(4096, (int)m_device_def.autodiscovery_def.accel[0].device_global_address);
+  CHECK_EQUAL(2048, (int)m_device_def.autodiscovery_def.accel[0].device_global_size);
+
 
   // Checks for device global entry.
   CHECK_EQUAL(2, m_device_def.autodiscovery_def.device_global_mem_defs.size());

--- a/test/acl_globals_test.cpp
+++ b/test/acl_globals_test.cpp
@@ -122,10 +122,9 @@ static acl_kernel_interface_t acltest_kernels[] = {
     {// interface
      "kernel15_dev_global",
      {
-         {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 1},
-         {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 1},
+         {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(void *), 0, 0, 1},
+         {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(void *), 0, 0, 1},
          {ACL_ARG_ADDR_NONE, ACL_ARG_BY_VALUE, sizeof(size_t), 0, 0},
-         //  {ACL_ARG_ADDR_NONE, ACL_ARG_BY_VALUE, sizeof(size_t), 0, 0},
      }}};
 
 template <typename T, std::size_t N>

--- a/test/acl_globals_test.cpp
+++ b/test/acl_globals_test.cpp
@@ -120,7 +120,7 @@ static acl_kernel_interface_t acltest_kernels[] = {
          {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 1024},
      }},
     {// interface
-     "kernel15_dev_global",
+     "copy_device_global",
      {
          {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(void *), 0, 0, 1},
          {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(void *), 0, 0, 1},
@@ -590,22 +590,31 @@ static acl_system_def_t acltest_complex_system = {
       1,
       0, /* alloc capabilities */
       0, /* min_host_mem_alignment */
-      {"fpga0",
-       "sample40byterandomhash000000000000000000",
-       0,
-       acltest_complex_system_device0_accel, /* accel */
-       {},                                   /* hal_info */
-       1,                                    // number of global memory systems
-       {
-           /* global mem info array */
-           {
-               /* global mem info for memory 0 */
-               /* global mem */ ACL_RANGE_FROM_ARRAY(acltest_global),
-               /* acl_system_global_mem_type_t */ ACL_GLOBAL_MEM_DEVICE_PRIVATE,
-               /* num_global_bank */ 2,
-               /* burst_interleaved */ 1,
-           },
-       }}},
+      {
+          "fpga0",
+          "sample40byterandomhash000000000000000000",
+          0,
+          acltest_complex_system_device0_accel, /* accel */
+          {},                                   /* hal_info */
+          1, // number of global memory systems
+          {
+              /* global mem info array */
+              {
+                  /* global mem info for memory 0 */
+                  /* global mem */ ACL_RANGE_FROM_ARRAY(acltest_global),
+                  /* acl_system_global_mem_type_t */
+                  ACL_GLOBAL_MEM_DEVICE_PRIVATE,
+                  /* num_global_bank */ 2,
+                  /* burst_interleaved */ 1,
+              },
+          },
+          {}, // acl_hostpipe_info
+          1,  // num_device_global
+          {
+              // device_global_mem_defs map
+              {"dev_global_name", {"dev_global_name", 0x1024, 2048}},
+          },
+      }},
      {nullptr,
       1,
       1,
@@ -615,22 +624,31 @@ static acl_system_def_t acltest_complex_system = {
       0,
       0, /* alloc capabilities */
       0, /* min_host_mem_alignment */
-      {"fpga1",
-       "sample40byterandomhash000000000000000001",
-       0,
-       acltest_complex_system_device1_accel, /* accel */
-       {},                                   /* hal_info */
-       1,                                    // number of global memory systems
-       {
-           /* global mem info array */
-           {
-               /* global mem info for memory 0 */
-               /* global mem */ ACL_RANGE_FROM_ARRAY(acltest_global),
-               /* acl_system_global_mem_type_t */ ACL_GLOBAL_MEM_DEVICE_PRIVATE,
-               /* num_global_bank */ 2,
-               /* burst_interleaved */ 1,
-           },
-       }}},
+      {
+          "fpga1",
+          "sample40byterandomhash000000000000000001",
+          0,
+          acltest_complex_system_device1_accel, /* accel */
+          {},                                   /* hal_info */
+          1, // number of global memory systems
+          {
+              /* global mem info array */
+              {
+                  /* global mem info for memory 0 */
+                  /* global mem */ ACL_RANGE_FROM_ARRAY(acltest_global),
+                  /* acl_system_global_mem_type_t */
+                  ACL_GLOBAL_MEM_DEVICE_PRIVATE,
+                  /* num_global_bank */ 2,
+                  /* burst_interleaved */ 1,
+              },
+          },
+          {}, // acl_hostpipe_info
+          1,  // num_device_global
+          {
+              // device_global_mem_defs map
+              {"dev_global_name", {"dev_global_name", 0x1024, 2048}},
+          },
+      }},
      {nullptr,
       2,
       1,

--- a/test/acl_globals_test.cpp
+++ b/test/acl_globals_test.cpp
@@ -198,20 +198,25 @@ static std::vector<acl_accel_def_t> acltest_complex_system_device0_accel = {
      {},
      {32768, 0, 0},
      1},
-    {14,
-     ACL_RANGE_FROM_ARRAY(acltest_devicelocal[11]),
-     acltest_kernels[14],
-     acltest_laspace_info,
-     {0, 0, 0},
-     0,
-     0,
-     1,
-     0,
-     32768,
-     3,
-     {},
-     {32768, 0, 0},
-     1},
+    {14,                                                // id
+     ACL_RANGE_FROM_ARRAY(acltest_devicelocal[11]),     // mem
+     acltest_kernels[14],                               // iface
+     acltest_laspace_info, // local_aspaces
+     {0, 0, 0}, // compile_work_group_size
+     0, // is_workgroup_invariant
+     0, // is_workitem_invariant
+     1, // num_vector_lanes
+     0, // profiling_words_to_readback
+     32768, // max_work_group_size
+     3, // max_global_work_dim
+     {}, // printf_format_info
+     {32768, 0, 0}, // max_work_group_size_arr
+     1, // uses_global_work_offset
+     0, // fast_launch_depth
+     1, // is_sycl_compile
+     4096, // device_global_address
+     2048, // device_global_size
+     },
     {1,
      ACL_RANGE_FROM_ARRAY(acltest_devicelocal[1]),
      acltest_kernels[1],

--- a/test/acl_globals_test.cpp
+++ b/test/acl_globals_test.cpp
@@ -118,6 +118,14 @@ static acl_kernel_interface_t acltest_kernels[] = {
          {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 8},
          {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 16},
          {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 1024},
+     }},
+    {// interface
+     "kernel15_dev_global",
+     {
+         {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 1},
+         {ACL_ARG_ADDR_GLOBAL, ACL_ARG_MEM_OBJ, sizeof(int *), 0, 0, 1},
+         {ACL_ARG_ADDR_NONE, ACL_ARG_BY_VALUE, sizeof(size_t), 0, 0},
+         //  {ACL_ARG_ADDR_NONE, ACL_ARG_BY_VALUE, sizeof(size_t), 0, 0},
      }}};
 
 template <typename T, std::size_t N>
@@ -185,6 +193,20 @@ static std::vector<acl_accel_def_t> acltest_complex_system_device0_accel = {
      0,
      0,
      4,
+     0,
+     32768,
+     3,
+     {},
+     {32768, 0, 0},
+     1},
+    {14,
+     ACL_RANGE_FROM_ARRAY(acltest_devicelocal[11]),
+     acltest_kernels[14],
+     acltest_laspace_info,
+     {0, 0, 0},
+     0,
+     0,
+     1,
      0,
      32768,
      3,

--- a/test/acl_globals_test.cpp
+++ b/test/acl_globals_test.cpp
@@ -198,25 +198,24 @@ static std::vector<acl_accel_def_t> acltest_complex_system_device0_accel = {
      {},
      {32768, 0, 0},
      1},
-    {14,                                                // id
-     ACL_RANGE_FROM_ARRAY(acltest_devicelocal[11]),     // mem
-     acltest_kernels[14],                               // iface
-     acltest_laspace_info, // local_aspaces
-     {0, 0, 0}, // compile_work_group_size
-     0, // is_workgroup_invariant
-     0, // is_workitem_invariant
-     1, // num_vector_lanes
-     0, // profiling_words_to_readback
-     32768, // max_work_group_size
-     3, // max_global_work_dim
-     {}, // printf_format_info
-     {32768, 0, 0}, // max_work_group_size_arr
-     1, // uses_global_work_offset
-     0, // fast_launch_depth
-     1, // is_sycl_compile
-     4096, // device_global_address
-     2048, // device_global_size
-     },
+    {
+        14,                                            // id
+        ACL_RANGE_FROM_ARRAY(acltest_devicelocal[11]), // mem
+        acltest_kernels[14],                           // iface
+        acltest_laspace_info,                          // local_aspaces
+        {0, 0, 0},     // compile_work_group_size
+        0,             // is_workgroup_invariant
+        0,             // is_workitem_invariant
+        1,             // num_vector_lanes
+        0,             // profiling_words_to_readback
+        32768,         // max_work_group_size
+        3,             // max_global_work_dim
+        {},            // printf_format_info
+        {32768, 0, 0}, // max_work_group_size_arr
+        1,             // uses_global_work_offset
+        0,             // fast_launch_depth
+        1,             // is_sycl_compile
+    },
     {1,
      ACL_RANGE_FROM_ARRAY(acltest_devicelocal[1]),
      acltest_kernels[1],

--- a/test/acl_program_test.cpp
+++ b/test/acl_program_test.cpp
@@ -612,7 +612,7 @@ MT_TEST(acl_program, program_info) {
   // built stat. to success even before calling clbuildprogram
   CHECK_EQUAL(CL_SUCCESS, clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES, 0,
                                            NULL, &size_ret));
-  CHECK_EQUAL(341, size_ret);
+  CHECK_EQUAL(340, size_ret);
 
   CHECK_EQUAL(CL_SUCCESS, clBuildProgram(program, 0, 0, "", 0, 0));
 
@@ -633,21 +633,22 @@ MT_TEST(acl_program, program_info) {
 
   CHECK_EQUAL(CL_SUCCESS, clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES, 0,
                                            NULL, &size_ret));
-  CHECK_EQUAL(341, size_ret);
+  CHECK_EQUAL(340, size_ret);
   // CHECK_EQUAL(321, size_ret);
 
   names[size_ret] = 100; // making sure extra bytes of memory are not affected.
   CHECK_EQUAL(CL_SUCCESS,
               clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES,
                                2000 * sizeof(char), names, &size_ret));
-  CHECK_EQUAL(341, size_ret); // only one kernel named: "foo"
+  CHECK_EQUAL(340, size_ret); // only one kernel named: "foo"
   CHECK_EQUAL(100, names[size_ret]);
-  CHECK_EQUAL(0, strcmp("kernel0_copy_vecin_vecout;"
+  CHECK_EQUAL(0, strcmp("copy_device_global;" // TODO: eventually we would want
+                                              // to hide it from users
+                        "kernel0_copy_vecin_vecout;"
                         "kernel11_task_double;"
                         "kernel12_task_double;"
                         "kernel13_multi_vec_lane;"
                         "kernel14_svm_arg_alignment;"
-                        "kernel15_dev_global;"
                         "kernel1_vecadd_vecin_vecin_vecout;"
                         "kernel2_vecscale_vecin_scalar_vecout;"
                         "kernel3_locals;"

--- a/test/acl_program_test.cpp
+++ b/test/acl_program_test.cpp
@@ -606,25 +606,25 @@ MT_TEST(acl_program, program_info) {
   // built stat. to success even before calling clbuildprogram
   CHECK_EQUAL(CL_SUCCESS, clGetProgramInfo(program, CL_PROGRAM_NUM_KERNELS,
                                            sizeof(size_t), &num_kernels, 0));
-  CHECK_EQUAL(14, num_kernels);
+  CHECK_EQUAL(15, num_kernels);
 
   // This won't happen if program is built with binary since we set the program
   // built stat. to success even before calling clbuildprogram
   CHECK_EQUAL(CL_SUCCESS, clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES, 0,
                                            NULL, &size_ret));
-  CHECK_EQUAL(321, size_ret);
+  CHECK_EQUAL(341, size_ret);
 
   CHECK_EQUAL(CL_SUCCESS, clBuildProgram(program, 0, 0, "", 0, 0));
 
   // after building the program
   CHECK_EQUAL(CL_SUCCESS, clGetProgramInfo(program, CL_PROGRAM_NUM_KERNELS,
                                            sizeof(size_t), &num_kernels, 0));
-  CHECK_EQUAL(14, num_kernels);
+  CHECK_EQUAL(15, num_kernels);
 
   CHECK_EQUAL(CL_SUCCESS,
               clGetProgramInfo(program, CL_PROGRAM_NUM_KERNELS, sizeof(size_t),
                                &num_kernels, &size_ret));
-  CHECK_EQUAL(14, num_kernels);
+  CHECK_EQUAL(15, num_kernels);
   CHECK_EQUAL(sizeof(size_t), size_ret);
 
   CHECK_EQUAL(CL_SUCCESS, clGetProgramInfo(program, CL_PROGRAM_NUM_KERNELS, 0,
@@ -633,19 +633,21 @@ MT_TEST(acl_program, program_info) {
 
   CHECK_EQUAL(CL_SUCCESS, clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES, 0,
                                            NULL, &size_ret));
-  CHECK_EQUAL(321, size_ret);
+  CHECK_EQUAL(341, size_ret);
+  // CHECK_EQUAL(321, size_ret);
 
   names[size_ret] = 100; // making sure extra bytes of memory are not affected.
   CHECK_EQUAL(CL_SUCCESS,
               clGetProgramInfo(program, CL_PROGRAM_KERNEL_NAMES,
                                2000 * sizeof(char), names, &size_ret));
-  CHECK_EQUAL(321, size_ret); // only one kernel named: "foo"
+  CHECK_EQUAL(341, size_ret); // only one kernel named: "foo"
   CHECK_EQUAL(100, names[size_ret]);
   CHECK_EQUAL(0, strcmp("kernel0_copy_vecin_vecout;"
                         "kernel11_task_double;"
                         "kernel12_task_double;"
                         "kernel13_multi_vec_lane;"
                         "kernel14_svm_arg_alignment;"
+                        "kernel15_dev_global;"
                         "kernel1_vecadd_vecin_vecin_vecout;"
                         "kernel2_vecscale_vecin_scalar_vecout;"
                         "kernel3_locals;"

--- a/test/acl_usm_test.cpp
+++ b/test/acl_usm_test.cpp
@@ -1268,15 +1268,15 @@ MT_TEST(acl_usm, read_device_global) {
 
   syncThreads();
   // Write to device global
-  status = clEnqueueWriteGlobalVariableINTEL(
-      m_cq, m_program, "kernel15_dev_global", CL_FALSE, strsize, 0, src_ptr, 0,
-      NULL, &write_event);
+  status = clEnqueueWriteGlobalVariableINTEL(m_cq, m_program, "dev_global_name",
+                                             CL_FALSE, strsize, 0, src_ptr, 0,
+                                             NULL, &write_event);
   CHECK_EQUAL(CL_SUCCESS, status);
 
   // Read from device global, with dependence on write event
-  status = clEnqueueReadGlobalVariableINTEL(
-      m_cq, m_program, "kernel15_dev_global", CL_FALSE, strsize, 0, src_ptr, 1,
-      &write_event, &read_event);
+  status = clEnqueueReadGlobalVariableINTEL(m_cq, m_program, "dev_global_name",
+                                            CL_FALSE, strsize, 0, src_ptr, 1,
+                                            &write_event, &read_event);
   CHECK_EQUAL(CL_SUCCESS, status);
 
   // Manually set "write device global" event done

--- a/test/acl_usm_test.cpp
+++ b/test/acl_usm_test.cpp
@@ -116,38 +116,16 @@ public:
   cl_program load_program() {
     cl_int status;
     cl_program program;
-    // const unsigned char *l_bin[m_num_devices];
-    // size_t l_bin_lengths[m_num_devices];
-    // cl_int l_bin_status[m_num_devices];
-    const unsigned char **l_bin = new const unsigned char *[m_num_devices];
-    size_t* l_bin_lengths = new size_t[m_num_devices];
-    cl_int* l_bin_status = new cl_int[m_num_devices];
-
-    for (cl_uint i = 0; i < m_num_devices; i++) {
-      l_bin[i] = (const unsigned char *)"0";
-      l_bin_lengths[i] = 1;
-    }
-
     status = CL_INVALID_VALUE;
-    size_t example_bin_len = 0;
-    const unsigned char *example_bin =
-        acl_test_get_example_binary(&example_bin_len);
-    program = clCreateProgramWithBinary(m_context, m_num_devices, &m_device[0],
-                                        l_bin_lengths, l_bin, &l_bin_status[0],
-                                        &status);
-    {
-      cl_uint i;
-      for (i = 0; i < m_num_devices; i++) {
-        CHECK_EQUAL(CL_SUCCESS, l_bin_status[i]);
-      }
-    }
+    const unsigned char *bin = (const unsigned char *)"0";
+    size_t bin_length = 1;
+    cl_int bin_status;
+    program = clCreateProgramWithBinary(m_context, 1, &m_device[0], &bin_length,
+                                        &bin, &bin_status, &status);
     CHECK_EQUAL(CL_SUCCESS, status);
     CHECK(program);
     ACL_LOCKED(CHECK(acl_program_is_valid(program)));
 
-    delete l_bin_status;
-    delete l_bin_lengths;
-    delete l_bin;
     return program;
   }
   void unload_program(cl_program program) {

--- a/test/acl_usm_test.cpp
+++ b/test/acl_usm_test.cpp
@@ -30,16 +30,6 @@
 #include <cstdio>
 #include <string.h>
 
-// A default empty program binary
-#define EXAMPLE_BINARY                                                         \
-  const unsigned char *l_bin[m_num_devices];                                   \
-  size_t l_bin_lengths[m_num_devices];                                         \
-  cl_int l_bin_status[m_num_devices];                                          \
-  for (cl_uint i = 0; i < m_num_devices; i++) {                                \
-    l_bin[i] = (const unsigned char *)"0";                                     \
-    l_bin_lengths[i] = 1;                                                      \
-  }
-
 static void CL_CALLBACK notify_me_print(const char *errinfo,
                                         const void *private_info, size_t cb,
                                         void *user_data);
@@ -126,7 +116,17 @@ public:
   cl_program load_program() {
     cl_int status;
     cl_program program;
-    EXAMPLE_BINARY;
+    // const unsigned char *l_bin[m_num_devices];
+    // size_t l_bin_lengths[m_num_devices];
+    // cl_int l_bin_status[m_num_devices];
+    const unsigned char **l_bin = new const unsigned char *[m_num_devices];
+    size_t* l_bin_lengths = new size_t[m_num_devices];
+    cl_int* l_bin_status = new cl_int[m_num_devices];
+
+    for (cl_uint i = 0; i < m_num_devices; i++) {
+      l_bin[i] = (const unsigned char *)"0";
+      l_bin_lengths[i] = 1;
+    }
 
     status = CL_INVALID_VALUE;
     size_t example_bin_len = 0;
@@ -144,6 +144,10 @@ public:
     CHECK_EQUAL(CL_SUCCESS, status);
     CHECK(program);
     ACL_LOCKED(CHECK(acl_program_is_valid(program)));
+
+    delete l_bin_status;
+    delete l_bin_lengths;
+    delete l_bin;
     return program;
   }
   void unload_program(cl_program program) {

--- a/test/acl_usm_test.cpp
+++ b/test/acl_usm_test.cpp
@@ -1261,10 +1261,6 @@ MT_TEST(acl_usm, read_device_global) {
   // Host pointer example
   void *src_ptr = malloc(strsize);
   CHECK(src_ptr != NULL);
-  // Host USM example
-  // void* src_ptr = clHostMemAllocINTEL(m_context, NULL, strsize, 1, &status);
-  // CHECK_EQUAL(CL_SUCCESS, status);
-  // CHECK(src_ptr != NULL);
 
   syncThreads();
   // Write to device global
@@ -1310,8 +1306,6 @@ MT_TEST(acl_usm, read_device_global) {
 
   // Host pointer example
   free(src_ptr);
-  // Host USM example
-  // CHECK_EQUAL(CL_SUCCESS, clMemFreeINTEL(m_context, src_ptr));
 
   ACL_LOCKED(acl_print_debug_msg("end read_write_buf\n"));
 }

--- a/test/acl_usm_test.cpp
+++ b/test/acl_usm_test.cpp
@@ -1301,8 +1301,8 @@ MT_TEST(acl_usm, read_device_global) {
                           ->image->activation_id;
   acltest_call_kernel_update_callback(activation_id, CL_RUNNING);
   acltest_call_kernel_update_callback(activation_id, CL_COMPLETE);
-  CHECK_EQUAL(CL_SUCCESS, clReleaseEvent(copy_event));
   CHECK_EQUAL(CL_SUCCESS, clFinish(m_cq));
+  CHECK_EQUAL(CL_SUCCESS, clReleaseEvent(copy_event));
 
   // Host pointer example
   free(src_ptr);


### PR DESCRIPTION
Migrated from Sherry's PR at https://github.com/intel/fpga-runtime-for-opencl/pull/65.

TODO: 
1) figure out what to do with acl_auto_configure.cpp and acl_auto_configure_test.cpp
2) address the problem "device global pointer is being mocked by passing an actual device allocation into the function"
3) Proof read and properly test the code