### PR TITLE
Fix Coverity issues for `acl_mem_test.cpp`

### DIFF
--- a/test/acl_mem_test.cpp
+++ b/test/acl_mem_test.cpp
@@ -1666,15 +1666,15 @@ MT_TEST(acl_mem, read_write_buf_rect) {
   cl_event read_event_rect = 0;
   cl_event read_event_1 = 0;
   cl_event read_event_2 = 0;
-  int input[8 * 8 * 8];
-  int output[8 * 8 * 8];
-  int check_val_1[8 * 8 * 8];
-  int check_val_2[8 * 8 * 8];
+  int input[8 * 8 * 8] = {};
+  int output[8 * 8 * 8] = {};
+  int check_val_1[8 * 8 * 8] = {};
+  int check_val_2[8 * 8 * 8] = {};
   size_t row_pitch = 8 * sizeof(int);
   size_t slice_pitch = 8 * row_pitch;
-  size_t src_offset[3];
-  size_t dst_offset[3];
-  size_t region[3];
+  size_t src_offset[3] = {};
+  size_t dst_offset[3] = {};
+  size_t region[3] = {};
 
   for (int i = 0; i < 8; ++i) {
     for (int j = 0; j < 8; ++j) {

--- a/test/acl_mem_test.cpp
+++ b/test/acl_mem_test.cpp
@@ -1608,8 +1608,8 @@ MT_TEST(acl_mem, read_write_buf) {
               trial, flagstrial1, flagstrial2, copy_event->id));
           this->check_event_perfcounters(copy_event);
           ACL_LOCKED(acl_print_debug_msg(
-              "trial %d flagstrial (%zu,%zu) read event %u perf check\n", trial,
-              flagstrial1, flagstrial2, read_event->id));
+              "trial %zu flagstrial (%zu,%zu) read event %u perf check\n",
+              trial, flagstrial1, flagstrial2, read_event->id));
           this->check_event_perfcounters(read_event);
           CHECK_EQUAL(CL_SUCCESS, clReleaseEvent(write_event));
           CHECK_EQUAL(CL_SUCCESS, clReleaseEvent(copy_event));


### PR DESCRIPTION
Summary of fixes:
- One `PRINTF_ARGS` Coverity issue was missed in https://github.com/intel/fpga-runtime-for-opencl/commit/2834ca29b68e1c3f4d51ccff89bdac9effe6618f
- Several arrays were uninitialized, causing Coverity to complain

The Coverity issues that were resolved have a lot of output, so I'll refrain from displaying them here.