### PR TITLE
Fix `TAINTED_SCALAR` Coverity issues for `pkg_editor.c`

### DIFF
--- a/lib/pkg_editor/src/pkg_editor.c
+++ b/lib/pkg_editor/src/pkg_editor.c
@@ -1628,6 +1628,14 @@ static int acl_pkg_unpack_buffer_or_file(const char *buffer, size_t buffer_size,
       break;
     }
 
+    // Make sure info.name_length bytes fit into our name buffer
+    if (info.name_length > NAME_LEN) {
+      fprintf(stderr, "%s: File name too long: %u\n", routine_name,
+              info.name_length);
+      inflateEnd(&z_info.strm);
+      return 0;
+    }
+
     // Read the filename.
     if (!read_data(name, info.name_length, &z_info, input)) {
       fprintf(stderr, "%s: Error reading file name from buffer\n",

--- a/lib/pkg_editor/test/CMakeLists.txt
+++ b/lib/pkg_editor/test/CMakeLists.txt
@@ -3,6 +3,12 @@
 
 add_executable(pkg_editor_test pkg_editor_test.cpp)
 target_link_libraries(pkg_editor_test PRIVATE CppUTest pkg_editor)
+
+# This section can be removed once the minimum required version of GCC has been raised to 9
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+       target_link_libraries(pkg_editor_test PRIVATE stdc++fs)
+endif()
+
 add_test(pkg_editor_test pkg_editor_test -v)
 
 if(ZLIB_FOUND)

--- a/lib/pkg_editor/test/pkg_editor_test.cpp
+++ b/lib/pkg_editor/test/pkg_editor_test.cpp
@@ -53,6 +53,8 @@ using random_bytes_engine =
                                  unsigned int>;
 namespace fs = std::experimental::filesystem::v1;
 
+int tmpCount = 0;
+
 static void l_remove_file(const char *filename) {
 #ifdef _WIN32
   _unlink(filename);
@@ -457,8 +459,9 @@ static bool is_same_tmpdir(const std::vector<fs::path> &files,
 
 TEST(package, unpack) {
   int result;
-  fs::path tmpdir = "tmp";
-  std::string tmpdir_string = tmpdir.string();
+  std::string tmpdir_string = "tmp" + std::to_string(tmpCount);
+  tmpCount++;
+  fs::path tmpdir = tmpdir_string;
   const char *tmpdir_c_str = tmpdir_string.c_str();
   std::vector<fs::path> files = generate_tmp_folder(tmpdir);
 
@@ -473,12 +476,14 @@ TEST(package, unpack) {
 
   // Compare some files to be sure that they are the same.
   CHECK(is_same_tmpdir(files, PACK_UNPACK_DIR));
+  system(("rm -rf " + tmpdir_string).c_str());
 }
 
 TEST(package, unpack_buffer) {
   int result;
-  fs::path tmpdir = "tmp";
-  std::string tmpdir_string = tmpdir.string();
+  std::string tmpdir_string = "tmp" + std::to_string(tmpCount);
+  tmpCount++;
+  fs::path tmpdir = tmpdir_string;
   const char *tmpdir_c_str = tmpdir_string.c_str();
   std::vector<fs::path> files = generate_tmp_folder(tmpdir);
   // Create a known good input.
@@ -509,12 +514,14 @@ TEST(package, unpack_buffer) {
   CHECK_EQUAL(true, files_same("test/pkg_editor_test.cpp",
                                PACK_UNPACK_DIR "/test/pkg_editor_test.cpp"));
   CHECK(is_same_tmpdir(files, PACK_UNPACK_DIR));
+  system(("rm -rf " + tmpdir_string).c_str());
 }
 
 TEST(package, unpack_buffer_stdin) {
   int result;
-  fs::path tmpdir = "tmp";
-  std::string tmpdir_string = tmpdir.string();
+  std::string tmpdir_string = "tmp" + std::to_string(tmpCount);
+  tmpCount++;
+  fs::path tmpdir = tmpdir_string;
   const char *tmpdir_c_str = tmpdir_string.c_str();
   std::vector<fs::path> files = generate_tmp_folder(tmpdir);
 
@@ -563,5 +570,6 @@ TEST(package, unpack_buffer_stdin) {
   CHECK_EQUAL(true, files_same("test/pkg_editor_test.cpp",
                                PACK_UNPACK_DIR "/test/pkg_editor_test.cpp"));
   CHECK(is_same_tmpdir(files, PACK_UNPACK_DIR));
+  system(("rm -rf " + tmpdir_string).c_str());
 }
 #endif

--- a/lib/pkg_editor/test/pkg_editor_test.cpp
+++ b/lib/pkg_editor/test/pkg_editor_test.cpp
@@ -382,6 +382,8 @@ TEST(package, pack) {
 static bool files_same(const char *f1, const char *f2) {
   std::ifstream file1(f1, std::ifstream::ate | std::ifstream::binary);
   std::ifstream file2(f2, std::ifstream::ate | std::ifstream::binary);
+  file1.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+  file2.exceptions(std::ifstream::failbit | std::ifstream::badbit);
   const std::ifstream::pos_type fileSize = file1.tellg();
 
   if (fileSize != file2.tellg()) {


### PR DESCRIPTION
Several values that were being read through files were not being checked to see if they meet certain requirements.

For one of the issues, the `info.name_length` variable was not being checked to see if it was less than the size of `name` when passed into `read_data`. This was a simple fix.

For the other `TAINTED_SCALAR` issue, the `info.file_length` value was never checked. Since this was being passed into a `malloc` call, it would be possible for the malloc call to use too much memory if the `info.file_length` number was purposefully set to be large. There were two possible solutions to this that I could think of
1. Add an upper bound to the size of `info.file_length`. This maintains much of the same code, but also increases the restrictions of the data being passed into the `acl_pkg_unpack_buffer_or_file` function.
2. Do not malloc an array of length `info.file_length` and instead reuse a constant sized array. This is the solution I implemented. 

Instead of mallocing and allocating memory, I added a while loop to reuse a constant sized array for multiple iterations. The only problem with this that I can foresee is it taking too much time and having multiple iterations of the while loop. However, when I ran the unit tests with and without this change, it took the same amount of time (although I'm not sure if the unit tests cover this case thoroughly). Are there any issues with this that come to mind, @pcolberg?

The error output is large, so I'll trim it down to just the issue without the code trace.

Fixes:
```
lib/pkg_editor/src/pkg_editor.c:1632:5:
  Type: Untrusted value as argument (TAINTED_SCALAR)

lib/pkg_editor/src/pkg_editor.c:1681:11:
  Type: Untrusted allocation size (TAINTED_SCALAR)
```