### PR TITLE
Auto discovery change for device global

### DIFF
--- a/include/acl.h
+++ b/include/acl.h
@@ -512,25 +512,16 @@ typedef enum {
   ACL_DEVICE_GLOBAL_HOST_ACCESS_TYPE_COUNT
 } acl_device_global_host_access_t;
 
-// Enum values here also need to match the SPIRV spec for device
-// global in the above link for acl_device_global_host_access_t.
-// ACL_DEVICE_GLOBAL_INIT_MODE_TYPE_COUNT is used for validation in
-// autodiscovery string parsing and should remain the last constant
-// in the enum.
-typedef enum {
-  ACL_DEVICE_GLOBAL_INIT_MODE_REPROGRAM,
-  ACL_DEVICE_GLOBAL_INIT_MODE_RESET,
-
-  ACL_DEVICE_GLOBAL_INIT_MODE_TYPE_COUNT
-} acl_device_global_init_mode_t;
-
 // Definition of device global.
 struct acl_device_global_mem_def_t {
   uint64_t address;
   uint32_t size;
   acl_device_global_host_access_t host_access;
-  acl_device_global_init_mode_t init_mode;
+  // every device global has the same value for can_skip_programming
+  bool can_skip_programming;
   bool implement_in_csr;
+  // every device global has the same value for reset_on_reuse
+  bool reset_on_reuse;
 };
 
 // Part of acl_device_def_t where members are populated from the information

--- a/src/acl_auto_configure.cpp
+++ b/src/acl_auto_configure.cpp
@@ -528,25 +528,29 @@ static bool read_device_global_mem_defs(
           static_cast<unsigned>(ACL_DEVICE_GLOBAL_HOST_ACCESS_TYPE_COUNT))
         result = false;
     }
-    auto init_mode =
-        static_cast<unsigned>(ACL_DEVICE_GLOBAL_INIT_MODE_REPROGRAM);
+    bool can_skip_programming = false;
     if (result && counters.back() > 0) {
-      result = read_uint_counters(config_str, curr_pos, init_mode, counters);
-      if (init_mode >=
-          static_cast<unsigned>(ACL_DEVICE_GLOBAL_INIT_MODE_TYPE_COUNT))
-        result = false;
+      result = read_bool_counters(config_str, curr_pos, can_skip_programming,
+                                  counters);
     }
     bool implement_in_csr = false;
     if (result && counters.back() > 0) {
       result =
           read_bool_counters(config_str, curr_pos, implement_in_csr, counters);
     }
+    bool reset_on_reuse = false;
+    if (result && counters.back() > 0) {
+      result =
+          read_bool_counters(config_str, curr_pos, reset_on_reuse, counters);
+    }
 
     acl_device_global_mem_def_t dev_global_def = {
-        dev_global_addr, dev_global_size,
+        dev_global_addr,
+        dev_global_size,
         static_cast<acl_device_global_host_access_t>(host_access),
-        static_cast<acl_device_global_init_mode_t>(init_mode),
-        implement_in_csr};
+        can_skip_programming,
+        implement_in_csr,
+        reset_on_reuse};
     bool ok =
         device_global_mem_defs.insert({device_global_name, dev_global_def})
             .second;

--- a/src/acl_kernel.cpp
+++ b/src/acl_kernel.cpp
@@ -3016,8 +3016,7 @@ bool acl_device_has_reprogram_device_globals(cl_device_id device) {
          std::find_if(device_global_mem_defs.begin(),
                       device_global_mem_defs.end(),
                       [](const auto &name_and_def) {
-                        return name_and_def.second.init_mode ==
-                               ACL_DEVICE_GLOBAL_INIT_MODE_REPROGRAM;
+                        return !name_and_def.second.can_skip_programming;
                       });
 }
 

--- a/test/acl_kernel_test.cpp
+++ b/test/acl_kernel_test.cpp
@@ -4350,8 +4350,9 @@ TEST(acl_kernel_reprogram_scheduler, device_global_reprogram) {
        {/* address */ 1024,
         /* size */ 1024,
         /* host_access */ ACL_DEVICE_GLOBAL_HOST_ACCESS_READ_WRITE,
-        /* init_mode */ ACL_DEVICE_GLOBAL_INIT_MODE_REPROGRAM,
-        /* implement_in_csr */ false}});
+        /* can_skip_programming */ false,
+        /* implement_in_csr */ false,
+        /* reset_on_reuse */ false}});
 
   // Initial eager reprogram
   int offset = m_devlog.num_ops;


### PR DESCRIPTION
For each device global, the init_mode field is changed to can_skip_programming field, a new field reset_on_reuse is added at the end.