### PR TITLE
Program scope hostpipe support

### DIFF
--- a/include/CL/cl_ext.h
+++ b/include/CL/cl_ext.h
@@ -2384,6 +2384,64 @@ clCreateBufferWithPropertiesINTEL_fn)(
     void *       host_ptr,
     cl_int *     errcode_ret) CL_API_SUFFIX__VERSION_1_0;
 
+/***********************************
+* cl_intel_program_scope_host_pipe *
+***********************************/
+#define cl_intel_program_scope_host_pipe 1
+#define CL_INTEL_PROGRAM_SCOPE_HOST_PIPE_EXTENSION_NAME "cl_intel_program_scope_host_pipe"
+
+/* New return values from clGetEventInfo when param_name is CL_EVENT_COMMAND_TYPE */
+#define CL_COMMAND_READ_HOST_PIPE_INTEL   0x4214
+#define CL_COMMAND_WRITE_HOST_PIPE_INTEL  0x4215
+#define CL_PROGRAM_NUM_HOST_PIPES_INTEL   0x4216
+#define CL_PROGRAM_HOST_PIPE_NAMES_INTEL  0x4217
+
+typedef cl_int (CL_API_CALL *clEnqueueReadHostPipeINTEL_fn )(
+            cl_command_queue command_queue,
+            cl_program program,
+            const char* pipe_symbol,
+            cl_bool blocking_read,
+            void* ptr,
+            size_t size,
+            cl_uint num_events_in_wait_list,
+            const cl_event* event_wait_list,
+            cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueReadHostPipeINTEL(
+            cl_command_queue command_queue,
+            cl_program program,
+            const char* pipe_symbol,
+            cl_bool blocking_read,
+            void* ptr,
+            size_t size,
+            cl_uint num_events_in_wait_list,
+            const cl_event* event_wait_list,
+            cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+
+typedef cl_int (CL_API_CALL *clEnqueueWriteHostPipeINTEL_fn)(
+            cl_command_queue command_queue,
+            cl_program program,
+            const char* pipe_symbol,
+            cl_bool blocking_write,
+            const void* ptr,
+            size_t size,
+            cl_uint num_events_in_wait_list,
+            const cl_event* event_wait_list,
+            cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+            
+extern CL_API_ENTRY cl_int CL_API_CALL
+clEnqueueWriteHostPipeINTEL(
+            cl_command_queue command_queue,
+            cl_program program,
+            const char* pipe_symbol,
+            cl_bool blocking_write,
+            const void* ptr,
+            size_t size,
+            cl_uint num_events_in_wait_list,
+            const cl_event* event_wait_list,
+            cl_event* event) CL_API_SUFFIX__VERSION_1_0;
+
 /******************************************
 * cl_intel_mem_channel_property extension *
 *******************************************/

--- a/include/acl.h
+++ b/include/acl.h
@@ -527,9 +527,14 @@ struct acl_device_global_mem_def_t {
 // Mapping of logical to physical host pipes.
 struct acl_hostpipe_mapping {
   std::string logical_name;
-  std::string physical_name;
+  std::string physical_name; // chan_id in the board_spec.xml
   bool implement_in_csr;
-  uintptr_t csr_address;
+  std::string csr_address; // Store this as string as this value can be '-' for
+                           // non-CSR pipe.
+  bool is_read;
+  bool is_write;
+  unsigned pipe_width;
+  unsigned pipe_depth;
 };
 
 // Part of acl_device_def_t where members are populated from the information

--- a/include/acl.h
+++ b/include/acl.h
@@ -524,6 +524,14 @@ struct acl_device_global_mem_def_t {
   bool reset_on_reuse;
 };
 
+// Mapping of logical to physical host pipes.
+struct acl_hostpipe_mapping {
+  std::string logical_name;
+  std::string physical_name;
+  bool implement_in_csr;
+  uintptr_t csr_address;
+};
+
 // Part of acl_device_def_t where members are populated from the information
 // in the autodiscovery string. This will get updated every time the device
 // is programmed with a new device binary as the new binary would contain a
@@ -548,6 +556,8 @@ typedef struct acl_device_def_autodiscovery_t {
       device_global_mem_defs;
   bool cra_ring_root_exist =
       true; // Set the default value to true for backwards compatibility flows.
+
+  std::vector<acl_hostpipe_mapping> hostpipe_mappings;
 } acl_device_def_autodiscovery_t;
 
 typedef struct acl_device_def_t {

--- a/include/acl_hal.h
+++ b/include/acl_hal.h
@@ -205,7 +205,7 @@ typedef struct {
                              size_t read_size, int *status);
   /// Push write_size of data to the device from host_buffer
   size_t (*hostchannel_push)(unsigned int physical_device_id,
-                             int channel_handle, void *host_buffer,
+                             int channel_handle, const void *host_buffer,
                              size_t write_size, int *status);
   /// Get a pointer to the mmd buffer for the host channel
   void *(*hostchannel_get_buffer)(unsigned int physical_device_id,
@@ -246,6 +246,12 @@ typedef struct {
   void (*simulation_streaming_kernel_done)(unsigned int physical_device_id,
                                            const std::string &signal_name,
                                            unsigned int &finish_counter);
+
+  size_t (*read_csr)(unsigned int physical_device_id, uintptr_t offset,
+                     void *ptr, size_t size);
+
+  size_t (*write_csr)(unsigned int physical_device_id, uintptr_t offset,
+                      const void *ptr, size_t size);
 } acl_hal_t;
 
 /// Linked list of MMD library names to load.

--- a/include/acl_hostch.h
+++ b/include/acl_hostch.h
@@ -27,6 +27,19 @@ void acl_bind_and_process_all_pipes_transactions(
     cl_context context, cl_device_id device,
     const acl_device_def_autodiscovery_t &devdef);
 
+// Submit a program hostpipe read device operation to the device op queue
+// acl_read_program_hostpipe will be invoked when the read op is RUNNING
+cl_int acl_submit_read_program_hostpipe_device_op(cl_event event);
+// Submit a program hostpipe write device operation to the device op queue
+cl_int acl_submit_write_program_hostpipe_device_op(cl_event event);
+
+// Read from a program hostpipe
+void acl_read_program_hostpipe(void *user_data, acl_device_op_t *op);
+
+// Write into a program hostpipe
+// acl_write_program_hostpipe will be invoked when the write op is RUNNING
+void acl_write_program_hostpipe(void *user_data, acl_device_op_t *op);
+
 #define HOST_TO_DEVICE 1
 #define DEVICE_TO_HOST 0
 

--- a/src/acl_command.cpp
+++ b/src/acl_command.cpp
@@ -16,6 +16,7 @@
 #include <acl_event.h>
 #include <acl_globals.h>
 #include <acl_hal.h>
+#include <acl_hostch.h>
 #include <acl_kernel.h>
 #include <acl_mem.h>
 #include <acl_program.h>
@@ -369,6 +370,14 @@ int acl_submit_command(cl_event event) {
 
     case CL_COMMAND_MIGRATE_MEM_OBJECTS:
       result = acl_submit_migrate_mem_device_op(event);
+      break;
+
+    case CL_COMMAND_READ_HOST_PIPE_INTEL:
+      result = acl_submit_read_program_hostpipe_device_op(event);
+      break;
+
+    case CL_COMMAND_WRITE_HOST_PIPE_INTEL:
+      result = acl_submit_write_program_hostpipe_device_op(event);
       break;
 
     default:

--- a/src/acl_device_op.cpp
+++ b/src/acl_device_op.cpp
@@ -15,6 +15,7 @@
 #include <acl_event.h>
 #include <acl_globals.h>
 #include <acl_hal.h>
+#include <acl_hostch.h>
 #include <acl_kernel.h>
 #include <acl_mem.h>
 #include <acl_printf.h>
@@ -108,47 +109,55 @@ static unsigned char conflict_matrix_half_duplex
     [ACL_NUM_CONFLICT_TYPES][ACL_NUM_CONFLICT_TYPES] = {
 
         //                      NONE, MEM_READ, MEM_WRITE, MEM_RW, KERNEL,
-        //                      PROGRAM
+        //                      PROGRAM, HOSTPIPE_READ, HOSTPIPE_WRITE
         // NONE vs.
-        {0, 0, 0, 0, 0, 1}
+        {0, 0, 0, 0, 0, 1, 0, 0}
         // MEM_READ  vs.
         ,
-        {0, 1, 1, 1, 0, 1}
+        {0, 1, 1, 1, 0, 1, 1, 1}
         // MEM_WRITE  vs.
         ,
-        {0, 1, 1, 1, 0, 1}
+        {0, 1, 1, 1, 0, 1, 1, 1}
         // MEM_RW  vs.
         ,
-        {0, 1, 1, 1, 0, 1}
+        {0, 1, 1, 1, 0, 1, 1, 1}
         // KERNEL vs.
         ,
-        {0, 0, 0, 0, 0, 1}
+        {0, 0, 0, 0, 0, 1, 0, 0}
         // PROGRAM vs.
         ,
-        {1, 1, 1, 1, 1, 1}};
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        // HOSTPIPE_READ vs.
+        {0, 1, 1, 1, 0, 1, 0, 0},
+        // HOSTPIPE_WRITE vs.
+        {0, 1, 1, 1, 0, 1, 0, 0}};
 
 static unsigned char conflict_matrix_full_duplex
     [ACL_NUM_CONFLICT_TYPES][ACL_NUM_CONFLICT_TYPES] = {
 
         //                      NONE, MEM_READ, MEM_WRITE, MEM_RW, KERNEL,
-        //                      PROGRAM
+        //                      PROGRAM, HOSTPIPE_READ, HOSTPIPE_WRITE
         // NONE vs.
-        {0, 0, 0, 0, 0, 1}
+        {0, 0, 0, 0, 0, 1, 0, 0}
         // MEM_READ  vs.
         ,
-        {0, 1, 0, 1, 0, 1}
+        {0, 1, 0, 1, 0, 1, 1, 1}
         // MEM_WRITE  vs.
         ,
-        {0, 0, 1, 1, 0, 1}
+        {0, 0, 1, 1, 0, 1, 1, 1}
         // MEM_RW  vs.
         ,
-        {0, 1, 1, 1, 0, 1}
+        {0, 1, 1, 1, 0, 1, 1, 1}
         // KERNEL vs.
         ,
-        {0, 0, 0, 0, 0, 1}
+        {0, 0, 0, 0, 0, 1, 0, 0}
         // PROGRAM vs.
         ,
-        {1, 1, 1, 1, 1, 1}};
+        {1, 1, 1, 1, 1, 1, 1, 1},
+        // HOSTPIPE_READ vs.
+        {0, 1, 1, 1, 0, 1, 0, 0},
+        // HOSTPIPE_WRITE vs.
+        {0, 1, 1, 1, 0, 1, 0, 0}};
 
 static const char *l_type_name(int op_type) {
   switch (op_type) {
@@ -175,6 +184,12 @@ static const char *l_type_name(int op_type) {
     break;
   case ACL_DEVICE_OP_USM_MEMCPY:
     return "USM_MEMCPY";
+    break;
+  case ACL_DEVICE_OP_HOSTPIPE_READ:
+    return "HOSTPIPE_READ";
+    break;
+  case ACL_DEVICE_OP_HOSTPIPE_WRITE:
+    return "HOSTPIPE_WRITE";
     break;
   default:
     return "<err>";
@@ -262,6 +277,8 @@ void acl_init_device_op_queue_limited(acl_device_op_queue_t *doq,
   doq->program_device = acl_program_device;
   doq->migrate_buffer = acl_mem_migrate_buffer;
   doq->usm_memcpy = acl_usm_memcpy;
+  doq->hostpipe_read = acl_read_program_hostpipe;
+  doq->hostpipe_write = acl_write_program_hostpipe;
   doq->log_update = 0;
 
   for (i = 0; i < ACL_MAX_DEVICE; i++) {
@@ -310,6 +327,12 @@ acl_device_op_conflict_type_t acl_device_op_conflict_type(acl_device_op_t *op) {
       break;
     case ACL_DEVICE_OP_REPROGRAM:
       result = ACL_CONFLICT_REPROGRAM;
+      break;
+    case ACL_DEVICE_OP_HOSTPIPE_READ:
+      result = ACL_CONFLICT_HOSTPIPE_READ;
+      break;
+    case ACL_DEVICE_OP_HOSTPIPE_WRITE:
+      result = ACL_CONFLICT_HOSTPIPE_WRITE;
       break;
     case ACL_DEVICE_OP_NONE:
     case ACL_NUM_DEVICE_OP_TYPES:
@@ -598,6 +621,15 @@ l_get_devices_affected_for_op(acl_device_op_t *op, unsigned int physical_ids[],
         num_devices_affected = 1;
       }
       break;
+    case ACL_DEVICE_OP_HOSTPIPE_READ:
+    case ACL_DEVICE_OP_HOSTPIPE_WRITE:
+      if (acl_event_is_valid(event) &&
+          acl_command_queue_is_valid(event->command_queue)) {
+        physical_ids[0] = event->command_queue->device->def.physical_device_id;
+        conflicts[0] = acl_device_op_conflict_type(op);
+        num_devices_affected = 1;
+      }
+      break;
     case ACL_DEVICE_OP_NONE:
     case ACL_NUM_DEVICE_OP_TYPES:
       break;
@@ -606,6 +638,7 @@ l_get_devices_affected_for_op(acl_device_op_t *op, unsigned int physical_ids[],
   if (num_devices_affected == 0) {
     // This case is only valid for unit tests
     // Make assumptions on which devices are affected
+    // Possible TODO to add for Hostpipe read and write
     if (event && event->context && op) {
       if (event->context->num_devices >= 2 &&
           op->info.type != ACL_DEVICE_OP_KERNEL &&
@@ -960,7 +993,9 @@ unsigned l_update_device_op_queue_once(acl_device_op_queue_t *doq) {
           } else if (op->info.event &&
                      (op->info.type == ACL_DEVICE_OP_MEM_TRANSFER_READ ||
                       op->info.type == ACL_DEVICE_OP_MEM_TRANSFER_WRITE ||
-                      op->info.type == ACL_DEVICE_OP_MEM_TRANSFER_COPY)) {
+                      op->info.type == ACL_DEVICE_OP_MEM_TRANSFER_COPY ||
+                      op->info.type == ACL_DEVICE_OP_HOSTPIPE_READ ||
+                      op->info.type == ACL_DEVICE_OP_HOSTPIPE_WRITE)) {
             if (!acl_mem_op_requires_transfer(op->info.event->cmd)) {
               is_conflicting = 0;
             }
@@ -1305,6 +1340,12 @@ void acl_submit_device_op(acl_device_op_queue_t *doq, acl_device_op_t *op) {
         break;
       case ACL_DEVICE_OP_USM_MEMCPY:
         DOIT(usm_memcpy, op);
+        break;
+      case ACL_DEVICE_OP_HOSTPIPE_READ:
+        DOIT(hostpipe_read, op);
+        break;
+      case ACL_DEVICE_OP_HOSTPIPE_WRITE:
+        DOIT(hostpipe_write, op);
         break;
       default:
         break;

--- a/src/acl_event.cpp
+++ b/src/acl_event.cpp
@@ -650,6 +650,10 @@ static void l_release_command_resources(acl_command_info_t &cmd) {
     cmd.info.memory_migration.num_alloc = 0;
     break;
 
+  case CL_COMMAND_READ_HOST_PIPE_INTEL:
+  case CL_COMMAND_WRITE_HOST_PIPE_INTEL:
+    // Nothing to cleanup
+    break;
   default:
     break;
   }
@@ -1150,6 +1154,8 @@ void acl_dump_event(cl_event event) {
     NNN(CL_COMMAND_MAP_BUFFER)
     NNN(CL_COMMAND_WAIT_FOR_EVENTS_INTELFPGA)
     NNN(CL_COMMAND_PROGRAM_DEVICE_INTELFPGA)
+    NNN(CL_COMMAND_READ_HOST_PIPE_INTEL)
+    NNN(CL_COMMAND_WRITE_HOST_PIPE_INTEL)
   default:
     break;
   }

--- a/src/acl_hostch.cpp
+++ b/src/acl_hostch.cpp
@@ -14,8 +14,11 @@
 // Internal headers.
 #include <acl.h>
 #include <acl_context.h>
+#include <acl_device_op.h>
+#include <acl_event.h>
 #include <acl_hostch.h>
 #include <acl_mem.h>
+#include <acl_platform.h>
 #include <acl_util.h>
 
 #ifdef __GNUC__
@@ -24,7 +27,7 @@
 
 /* Local Functions */
 static cl_int l_push_packet(unsigned int physical_device_id, int channel_handle,
-                            void *host_buffer, size_t write_size) {
+                            const void *host_buffer, size_t write_size) {
   size_t pushed_data;
   int status = 0;
 
@@ -678,6 +681,404 @@ clUnmapHostPipeIntelFPGA(cl_mem pipe, void *mapped_ptr, size_t size_to_unmap,
     }
   }
   acl_mutex_unlock(&(pipe->host_pipe_info->m_lock));
+
+  return CL_SUCCESS;
+}
+
+// Ideally this should be passed from the autodiscovery string.
+static constexpr unsigned csr_pipe_address_offet = 8;
+
+void acl_read_program_hostpipe(void *user_data, acl_device_op_t *op) {
+
+  cl_event event = op->info.event;
+  cl_int status = 0;
+  size_t pulled_data = 0;
+  bool blocking = event->cmd.info.host_pipe_info.blocking;
+  acl_assert_locked();
+
+  if (!acl_event_is_valid(event) ||
+      !acl_command_queue_is_valid(event->command_queue)) {
+    acl_set_device_op_execution_status(op, -1);
+    return;
+  }
+
+  acl_device_program_info_t *dev_prog =
+      event->command_queue->device->loaded_bin->get_dev_prog();
+  auto host_pipe_info = dev_prog->program_hostpipe_map.at(
+      std::string(event->cmd.info.host_pipe_info.logical_name));
+  acl_mutex_lock(&(host_pipe_info.m_lock));
+  acl_set_device_op_execution_status(op, CL_SUBMITTED);
+  acl_set_device_op_execution_status(op, CL_RUNNING);
+
+  if (host_pipe_info.implement_in_csr) {
+    // CSR read, currently only blocking version is implemented
+    unsigned long long parsed;
+    uintptr_t data_reg, ready_reg, valid_reg;
+    // Convert the CSR address to a pointer
+    try {
+      parsed = std::stoull(host_pipe_info.csr_address, nullptr);
+    } catch (const std::exception &) {
+
+      acl_set_device_op_execution_status(op, -1);
+      return;
+    }
+
+    data_reg = static_cast<uintptr_t>(parsed);
+    ready_reg = static_cast<uintptr_t>(
+        parsed +
+        csr_pipe_address_offet); // ready reg is data reg shift by 8 byte
+    valid_reg = static_cast<uintptr_t>(
+        parsed +
+        csr_pipe_address_offet * 2); // valid reg is ready reg shift by 8 byte
+    unsigned ready = 1;
+    unsigned valid_value;
+    unsigned *valid_value_pointer = &valid_value;
+
+    // start the CSR read
+
+    // Checking if the data is valid, blocking
+    do {
+      acl_get_hal()->read_csr(host_pipe_info.m_physical_device_id, valid_reg,
+                              (void *)valid_value_pointer,
+                              (size_t)sizeof(uintptr_t));
+    } while (valid_value != 1);
+
+    pulled_data =
+        acl_get_hal()->read_csr(host_pipe_info.m_physical_device_id, data_reg,
+                                event->cmd.info.host_pipe_info.ptr,
+                                event->cmd.info.host_pipe_info.size);
+    // Tell CSR it's ready
+    acl_get_hal()->write_csr(host_pipe_info.m_physical_device_id, ready_reg,
+                             (void *)&ready, (size_t)sizeof(uintptr_t));
+  } else {
+    // Non CSR Case
+    pulled_data = acl_get_hal()->hostchannel_pull(
+        host_pipe_info.m_physical_device_id, host_pipe_info.m_channel_handle,
+        event->cmd.info.host_pipe_info.ptr, event->cmd.info.host_pipe_info.size,
+        &status);
+
+    if (!blocking) {
+      // If it is non-blocking read, we return with the success code right away
+      if (status != 0 || pulled_data != event->cmd.info.host_pipe_info.size) {
+        acl_mutex_unlock(&(host_pipe_info.m_lock));
+        acl_set_device_op_execution_status(op, -1);
+        return;
+      }
+    } else {
+      // If it is a blocking read, this call won't return until the kernel
+      // writes the data into the pipe.
+      while (status != 0 ||
+             pulled_data != event->cmd.info.host_pipe_info.size) {
+        pulled_data = acl_get_hal()->hostchannel_pull(
+            host_pipe_info.m_physical_device_id,
+            host_pipe_info.m_channel_handle, event->cmd.info.host_pipe_info.ptr,
+            event->cmd.info.host_pipe_info.size, &status);
+      }
+    }
+  }
+
+  acl_mutex_unlock(&(host_pipe_info.m_lock));
+  acl_set_device_op_execution_status(op, CL_COMPLETE);
+}
+
+void acl_write_program_hostpipe(void *user_data, acl_device_op_t *op) {
+
+  cl_int status;
+  cl_event event = op->info.event;
+  cl_context context = event->context;
+  bool blocking = event->cmd.info.host_pipe_info.blocking;
+  acl_assert_locked();
+
+  if (!acl_event_is_valid(event) ||
+      !acl_command_queue_is_valid(event->command_queue)) {
+    acl_set_device_op_execution_status(op, -1);
+    return;
+  }
+
+  acl_device_program_info_t *dev_prog =
+      event->command_queue->device->loaded_bin->get_dev_prog();
+  auto host_pipe_info = dev_prog->program_hostpipe_map.at(
+      std::string(event->cmd.info.host_pipe_info.logical_name));
+  acl_mutex_lock(&(host_pipe_info.m_lock));
+  acl_set_device_op_execution_status(op, CL_SUBMITTED);
+  acl_set_device_op_execution_status(op, CL_RUNNING);
+
+  if (host_pipe_info.implement_in_csr) {
+    // Get CSR address
+    unsigned long long parsed;
+    uintptr_t data_reg, valid_reg;
+    size_t pushed_data;
+    try {
+      parsed = std::stoull(host_pipe_info.csr_address, nullptr);
+    } catch (const std::exception &) {
+      acl_set_device_op_execution_status(op, -1);
+      return;
+    }
+    data_reg = static_cast<uintptr_t>(parsed);
+    valid_reg = static_cast<uintptr_t>(
+        parsed +
+        csr_pipe_address_offet); // valid reg is data reg shift by 8 byte, move
+                                 // this to the autodiscovery string maybe
+    unsigned int valid = 1;
+    // start the write
+    pushed_data =
+        acl_get_hal()->write_csr(host_pipe_info.m_physical_device_id, data_reg,
+                                 event->cmd.info.host_pipe_info.write_ptr,
+                                 event->cmd.info.host_pipe_info.size);
+    if (pushed_data != event->cmd.info.host_pipe_info.size) {
+      acl_mutex_unlock(&(host_pipe_info.m_lock));
+      acl_set_device_op_execution_status(op, -1);
+      return;
+    }
+    // Tell CSR it's valid
+    acl_get_hal()->write_csr(host_pipe_info.m_physical_device_id, valid_reg,
+                             (void *)&valid, (size_t)sizeof(uintptr_t));
+  } else {
+    // Regular hostpipe
+    // Attempt to write once
+    status = l_push_packet(host_pipe_info.m_physical_device_id,
+                           host_pipe_info.m_channel_handle,
+                           event->cmd.info.host_pipe_info.write_ptr,
+                           event->cmd.info.host_pipe_info.size);
+    if (!blocking) {
+      // If it is non-blocking write, we return with the success/failure code
+      // right away
+      if (status != CL_SUCCESS) {
+        acl_mutex_unlock(&(host_pipe_info.m_lock));
+        acl_set_device_op_execution_status(op, -1);
+        return;
+      }
+    } else {
+      // If it's a blocking write, this function won't return until the write
+      // success.
+      while (status != CL_SUCCESS) {
+        status = l_push_packet(host_pipe_info.m_physical_device_id,
+                               host_pipe_info.m_channel_handle,
+                               event->cmd.info.host_pipe_info.write_ptr,
+                               event->cmd.info.host_pipe_info.size);
+      }
+    }
+  }
+  acl_mutex_unlock(&(host_pipe_info.m_lock));
+  acl_set_device_op_execution_status(op, CL_COMPLETE);
+}
+
+// Submit an op to the device op queue to read hostpipe.
+// Return 1 if we made forward progress, 0 otherwise.
+cl_int acl_submit_read_program_hostpipe_device_op(cl_event event) {
+  int result = 0;
+  acl_assert_locked();
+
+  // No user-level scheduling blocks this hostpipe read
+  // So submit it to the device op queue.
+  // But only if it isn't already enqueued there.
+  if (!acl_event_is_valid(event)) {
+    return result;
+  }
+  // Already enqueued.
+  if (event->last_device_op) {
+    return result;
+  }
+
+  acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+  acl_device_op_t *last_op = 0;
+
+  // Precautionary, but it also nudges the device scheduler to try
+  // to free up old operation slots.
+  acl_forget_proposed_device_ops(doq);
+
+  last_op = acl_propose_device_op(doq, ACL_DEVICE_OP_HOSTPIPE_READ,
+                                  event); // TODO Change this to the READ op
+
+  if (last_op) {
+    // We managed to enqueue everything.
+    event->last_device_op = last_op;
+    acl_commit_proposed_device_ops(doq);
+    result = 1;
+  } else {
+    // Back off, and wait until later when we have more space in the
+    // device op queue.
+    acl_forget_proposed_device_ops(doq);
+  }
+  return result;
+}
+
+// Submit an op to the device op queue to write hostpipe.
+// Return 1 if we made forward progress, 0 otherwise.
+cl_int acl_submit_write_program_hostpipe_device_op(cl_event event) {
+  int result = 0;
+  acl_assert_locked();
+
+  // No user-level scheduling blocks this hostpipe write op
+  // So submit it to the device op queue.
+  // But only if it isn't already enqueued there.
+  if (!acl_event_is_valid(event)) {
+    return result;
+  }
+  // Already enqueued.
+  if (event->last_device_op) {
+    return result;
+  }
+
+  acl_device_op_queue_t *doq = &(acl_platform.device_op_queue);
+  acl_device_op_t *last_op = 0;
+
+  // Precautionary, but it also nudges the device scheduler to try
+  // to free up old operation slots.
+  acl_forget_proposed_device_ops(doq);
+
+  last_op = acl_propose_device_op(doq, ACL_DEVICE_OP_HOSTPIPE_WRITE, event);
+
+  if (last_op) {
+    // We managed to enqueue everything.
+    event->last_device_op = last_op;
+    acl_commit_proposed_device_ops(doq);
+    result = 1;
+  } else {
+    // Back off, and wait until later when we have more space in the
+    // device op queue.
+    acl_forget_proposed_device_ops(doq);
+  }
+  return result;
+}
+
+ACL_EXPORT
+CL_API_ENTRY cl_int CL_API_CALL clEnqueueReadHostPipeINTEL(
+    cl_command_queue command_queue, cl_program program, const char *pipe_symbol,
+    cl_bool blocking_read, void *ptr, size_t size,
+    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
+    cl_event *event) {
+
+  cl_int status = 0;
+
+  // Get context from program, command_queue and event
+  cl_context context = program->context;
+  cl_device_id device = command_queue->device;
+
+  std::scoped_lock lock{acl_mutex_wrapper};
+
+  if (ptr == NULL) {
+    ERR_RET(CL_INVALID_VALUE, context,
+            "Invalid pointer was provided to host data");
+  }
+
+  if (pipe_symbol == NULL) {
+    ERR_RET(CL_INVALID_VALUE, context, "Invalid Pipe Symbol");
+  }
+
+  acl_device_program_info_t *dev_prog = device->loaded_bin->get_dev_prog();
+
+  auto search = dev_prog->program_hostpipe_map.find(std::string(pipe_symbol));
+
+  if (search == dev_prog->program_hostpipe_map.end()) {
+    ERR_RET(CL_INVALID_VALUE, context,
+            "Pipe Symbol is not found in the device");
+  }
+
+  if (search == dev_prog->program_hostpipe_map.end()) {
+
+    ERR_RET(CL_INVALID_VALUE, context,
+            "Pipe Symbol is not found in the device");
+  }
+
+  cl_event local_event = 0; // used for blocking
+
+  // Create an event/command to actually move the data at the appropriate
+  // time.
+  status =
+      acl_create_event(command_queue, num_events_in_wait_list, event_wait_list,
+                       CL_COMMAND_READ_HOST_PIPE_INTEL, &local_event);
+
+  if (status != CL_SUCCESS)
+    return status;
+
+  local_event->cmd.info.host_pipe_info.size = size;
+  local_event->cmd.info.host_pipe_info.ptr = ptr;
+  local_event->cmd.info.host_pipe_info.blocking = blocking_read;
+  local_event->cmd.info.host_pipe_info.logical_name = pipe_symbol;
+
+  acl_idle_update(
+      command_queue
+          ->context); // If nothing's blocking, then complete right away
+
+  if (blocking_read) {
+    status = clWaitForEvents(1, &local_event);
+  }
+
+  if (event) {
+    *event = local_event;
+  } else {
+    // User didn't care, so forget about the event.
+    clReleaseEvent(local_event);
+    acl_idle_update(command_queue->context); // Clean up early
+  }
+
+  return CL_SUCCESS;
+}
+
+ACL_EXPORT
+CL_API_ENTRY cl_int CL_API_CALL clEnqueueWriteHostPipeINTEL(
+    cl_command_queue command_queue, cl_program program, const char *pipe_symbol,
+    cl_bool blocking_write, const void *ptr, size_t size,
+    cl_uint num_events_in_wait_list, const cl_event *event_wait_list,
+    cl_event *event) {
+
+  cl_int status = 0;
+  // Get context from program, command_queue and event
+  cl_context context = program->context;
+  cl_device_id device = command_queue->device;
+
+  std::scoped_lock lock{acl_mutex_wrapper};
+
+  if (ptr == NULL) {
+    ERR_RET(CL_INVALID_VALUE, context,
+            "Invalid pointer was provided to host data");
+  }
+
+  if (pipe_symbol == NULL) {
+    ERR_RET(CL_INVALID_VALUE, context, "Invalid Pipe Symbol");
+  }
+
+  acl_device_program_info_t *dev_prog = device->loaded_bin->get_dev_prog();
+
+  auto search = dev_prog->program_hostpipe_map.find(std::string(pipe_symbol));
+
+  if (search == dev_prog->program_hostpipe_map.end()) {
+
+    ERR_RET(CL_INVALID_VALUE, context,
+            "Pipe Symbol is not found in the device");
+  }
+
+  cl_event local_event = 0; // used for blocking
+
+  // Create an event/command to actually move the data at the appropriate time.
+  status =
+      acl_create_event(command_queue, num_events_in_wait_list, event_wait_list,
+                       CL_COMMAND_WRITE_HOST_PIPE_INTEL, &local_event);
+
+  if (status != CL_SUCCESS)
+    return status;
+
+  local_event->cmd.info.host_pipe_info.size = size;
+  local_event->cmd.info.host_pipe_info.write_ptr = ptr;
+  local_event->cmd.info.host_pipe_info.blocking = blocking_write;
+  local_event->cmd.info.host_pipe_info.logical_name = pipe_symbol;
+
+  acl_idle_update(
+      command_queue
+          ->context); // If nothing's blocking, then complete right away
+
+  if (blocking_write) {
+    status = clWaitForEvents(1, &local_event);
+  }
+
+  if (event) {
+    *event = local_event;
+  } else {
+    // User didn't care, so forget about the event.
+    clReleaseEvent(local_event);
+    acl_idle_update(command_queue->context); // Clean up early
+  }
 
   return CL_SUCCESS;
 }

--- a/src/acl_icd_dispatch.cpp
+++ b/src/acl_icd_dispatch.cpp
@@ -50,6 +50,8 @@ clGetExtensionFunctionAddressIntelFPGA(const char *func_name) {
   ADDFUNCTIONLOOKUP(clResetKernelsIntelFPGA);
   ADDFUNCTIONLOOKUP(clSetBoardLibraryIntelFPGA);
   ADDFUNCTIONLOOKUP(clCreateBufferWithPropertiesINTEL);
+  ADDFUNCTIONLOOKUP(clEnqueueReadHostPipeINTEL);
+  ADDFUNCTIONLOOKUP(clEnqueueWriteHostPipeINTEL);
 
 // USM APIs are not currently supported on 32bit devices
 #ifndef __arm__

--- a/src/acl_platform.cpp
+++ b/src/acl_platform.cpp
@@ -282,7 +282,8 @@ const char *acl_platform_extensions() {
 #endif
          " cl_intel_create_buffer_with_properties"
          " cl_intel_mem_channel_property"
-         " cl_intel_mem_alloc_buffer_location";
+         " cl_intel_mem_alloc_buffer_location"
+         " cl_intel_program_scope_host_pipe";
 }
 
 // Initialize the internal bookkeeping based on the system definition

--- a/src/acl_profiler.cpp
+++ b/src/acl_profiler.cpp
@@ -836,6 +836,10 @@ int acl_process_profiler_scan_chain(acl_device_op_t *op) {
     snprintf(name, MAX_NAME_SIZE, ".mem_migration");
   } else if (op_type == ACL_DEVICE_OP_USM_MEMCPY) {
     snprintf(name, MAX_NAME_SIZE, ".usm_memcpy");
+  } else if (op_type == ACL_DEVICE_OP_HOSTPIPE_READ) {
+    snprintf(name, MAX_NAME_SIZE, ".hostpipe_read");
+  } else if (op_type == ACL_DEVICE_OP_HOSTPIPE_WRITE) {
+    snprintf(name, MAX_NAME_SIZE, ".hostpipe_write");
   } else {
     // Ignore unknown op_type (don't attempt to extract any profiling from it or
     // get timestamps)

--- a/test/acl_auto_configure_test.cpp
+++ b/test/acl_auto_configure_test.cpp
@@ -1487,3 +1487,63 @@ TEST(auto_configure, cra_ring_root_exist) {
 
   CHECK_EQUAL(1, devdef.cra_ring_root_exist);
 }
+
+// Will finalize later, Zibai todo.
+
+// TEST(auto_configure, hostpipe_mappings) {
+//   const std::string config_str{
+//       "23 45 " RANDOM_HASH
+//       " pac_a10 0 1 13 DDR 2 2 24 1 2 0 4294967296 4294967296 8589934592 0 - 0 "
+//       "0 0 0 0 0 5 4 pipe_logical_name1 pipe_physical_name1 1 12345 "
+//       "pipe_logical_name2 pipe_physical_name2 0 12323 pipe_logical_name3 "
+//       "pipe_physical_name1 1 12313 pipe_logical_name1 pipe_physical_name1 0 "
+//       "12316 pipe_logical_name1 pipe_physical_name3 0 12342 3 90 "
+//       "_ZTS3CRCILi0EE 512 256 1 0 0 1 0 1 0 9 6 0 0 8 1 0 0 6 2 1 8 1024 0 3 6 "
+//       "0 0 8 1 0 0 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 "
+//       "6 0 0 8 1 0 0 6 0 0 8 1 0 0 0 0 1 2 64 4096 1 1 1 3 1 1 1 3 1 0 64 "
+//       "_ZTS11LZReductionILi0EE 0 256 1 0 0 0 0 1 0 5 6 0 0 8 1 0 0 6 2 1 8 "
+//       "1024 0 3 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 0 0 8 1 0 0 0 0 2 2 64 131072 65 "
+//       "32768 1 1 1 3 1 1 1 3 1 0 125 _ZTS13StaticHuffmanILi0EE 256 256 1 0 0 1 "
+//       "0 1 0 10 6 0 0 8 1 0 0 6 0 0 4 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 6 0 "
+//       "0 8 1 0 0 6 0 0 8 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 "
+//       "0 0 8 1 0 0 0 0 15 2 64 116 65 116 66 1152 67 512 68 256 69 120 70 120 "
+//       "71 1152 72 116 73 1152 74 512 75 256 76 120 77 120 78 1152 1 1 1 3 1 1 "
+//       "1 3 1 0"};
+
+//   acl_device_def_autodiscovery_t devdef;
+//   {
+//     bool result;
+//     std::string err_str;
+//     ACL_LOCKED(result =
+//                    acl_load_device_def_from_str(config_str, devdef, err_str));
+//     std::cerr << err_str;
+//     CHECK(result);
+//   }
+
+//   CHECK_EQUAL(5, devdef.hostpipe_mappings.size());
+
+//   CHECK(devdef.hostpipe_mappings[0].logical_name == "pipe_logical_name1");
+//   CHECK(devdef.hostpipe_mappings[0].physical_name == "pipe_physical_name1");
+//   CHECK(devdef.hostpipe_mappings[0].implement_in_csr);
+//   CHECK(devdef.hostpipe_mappings[0].csr_address == 12345);
+
+//   CHECK(devdef.hostpipe_mappings[1].logical_name == "pipe_logical_name2");
+//   CHECK(devdef.hostpipe_mappings[1].physical_name == "pipe_physical_name2");
+//   CHECK(!devdef.hostpipe_mappings[1].implement_in_csr);
+//   CHECK(devdef.hostpipe_mappings[1].csr_address == 12323);
+
+//   CHECK(devdef.hostpipe_mappings[2].logical_name == "pipe_logical_name3");
+//   CHECK(devdef.hostpipe_mappings[2].physical_name == "pipe_physical_name1");
+//   CHECK(devdef.hostpipe_mappings[2].implement_in_csr);
+//   CHECK(devdef.hostpipe_mappings[2].csr_address == 12313);
+
+//   CHECK(devdef.hostpipe_mappings[3].logical_name == "pipe_logical_name1");
+//   CHECK(devdef.hostpipe_mappings[3].physical_name == "pipe_physical_name1");
+//   CHECK(!devdef.hostpipe_mappings[3].implement_in_csr);
+//   CHECK(devdef.hostpipe_mappings[3].csr_address == 12316);
+
+//   CHECK(devdef.hostpipe_mappings[4].logical_name == "pipe_logical_name1");
+//   CHECK(devdef.hostpipe_mappings[4].physical_name == "pipe_physical_name3");
+//   CHECK(!devdef.hostpipe_mappings[4].implement_in_csr);
+//   CHECK(devdef.hostpipe_mappings[4].csr_address == 12342);
+// }

--- a/test/acl_auto_configure_test.cpp
+++ b/test/acl_auto_configure_test.cpp
@@ -1488,62 +1488,83 @@ TEST(auto_configure, cra_ring_root_exist) {
   CHECK_EQUAL(1, devdef.cra_ring_root_exist);
 }
 
-// Will finalize later, Zibai todo.
+TEST(auto_configure, hostpipe_mappings) {
+  const std::string config_str{
+      "23 66 " RANDOM_HASH
+      " pac_a10 0 1 13 DDR 2 2 24 1 2 0 4294967296 4294967296 8589934592 0 - 0 "
+      "0 0 0 0 0 1 5 8 pipe_logical_name1 pipe_physical_name1 1 12345 0 1 4 10 "
+      "pipe_logical_name2 pipe_physical_name2 0 12323 1 0 8 20 "
+      "pipe_logical_name3 "
+      "pipe_physical_name1 1 12313 0 1 4 10 pipe_logical_name5 "
+      "pipe_physical_name1 0 "
+      "12316 1 0 8 20 pipe_logical_name4 pipe_physical_name3 0 12342 0 1 4 10 "
+      "3 90 "
+      "_ZTS3CRCILi0EE 512 256 1 0 0 1 0 1 0 9 6 0 0 8 1 0 0 6 2 1 8 1024 0 3 6 "
+      "0 0 8 1 0 0 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 "
+      "6 0 0 8 1 0 0 6 0 0 8 1 0 0 0 0 1 2 64 4096 1 1 1 3 1 1 1 3 1 0 64 "
+      "_ZTS11LZReductionILi0EE 0 256 1 0 0 0 0 1 0 5 6 0 0 8 1 0 0 6 2 1 8 "
+      "1024 0 3 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 0 0 8 1 0 0 0 0 2 2 64 131072 65 "
+      "32768 1 1 1 3 1 1 1 3 1 0 125 _ZTS13StaticHuffmanILi0EE 256 256 1 0 0 1 "
+      "0 1 0 10 6 0 0 8 1 0 0 6 0 0 4 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 6 0 "
+      "0 8 1 0 0 6 0 0 8 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 "
+      "0 0 8 1 0 0 0 0 15 2 64 116 65 116 66 1152 67 512 68 256 69 120 70 120 "
+      "71 1152 72 116 73 1152 74 512 75 256 76 120 77 120 78 1152 1 1 1 3 1 1 "
+      "1 3 1 0"};
 
-// TEST(auto_configure, hostpipe_mappings) {
-//   const std::string config_str{
-//       "23 45 " RANDOM_HASH
-//       " pac_a10 0 1 13 DDR 2 2 24 1 2 0 4294967296 4294967296 8589934592 0 - 0 "
-//       "0 0 0 0 0 5 4 pipe_logical_name1 pipe_physical_name1 1 12345 "
-//       "pipe_logical_name2 pipe_physical_name2 0 12323 pipe_logical_name3 "
-//       "pipe_physical_name1 1 12313 pipe_logical_name1 pipe_physical_name1 0 "
-//       "12316 pipe_logical_name1 pipe_physical_name3 0 12342 3 90 "
-//       "_ZTS3CRCILi0EE 512 256 1 0 0 1 0 1 0 9 6 0 0 8 1 0 0 6 2 1 8 1024 0 3 6 "
-//       "0 0 8 1 0 0 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 "
-//       "6 0 0 8 1 0 0 6 0 0 8 1 0 0 0 0 1 2 64 4096 1 1 1 3 1 1 1 3 1 0 64 "
-//       "_ZTS11LZReductionILi0EE 0 256 1 0 0 0 0 1 0 5 6 0 0 8 1 0 0 6 2 1 8 "
-//       "1024 0 3 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 0 0 8 1 0 0 0 0 2 2 64 131072 65 "
-//       "32768 1 1 1 3 1 1 1 3 1 0 125 _ZTS13StaticHuffmanILi0EE 256 256 1 0 0 1 "
-//       "0 1 0 10 6 0 0 8 1 0 0 6 0 0 4 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 6 0 "
-//       "0 8 1 0 0 6 0 0 8 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 "
-//       "0 0 8 1 0 0 0 0 15 2 64 116 65 116 66 1152 67 512 68 256 69 120 70 120 "
-//       "71 1152 72 116 73 1152 74 512 75 256 76 120 77 120 78 1152 1 1 1 3 1 1 "
-//       "1 3 1 0"};
+  acl_device_def_autodiscovery_t devdef;
+  {
+    bool result;
+    std::string err_str;
+    ACL_LOCKED(result =
+                   acl_load_device_def_from_str(config_str, devdef, err_str));
+    std::cerr << err_str;
+    CHECK(result);
+  }
 
-//   acl_device_def_autodiscovery_t devdef;
-//   {
-//     bool result;
-//     std::string err_str;
-//     ACL_LOCKED(result =
-//                    acl_load_device_def_from_str(config_str, devdef, err_str));
-//     std::cerr << err_str;
-//     CHECK(result);
-//   }
+  CHECK_EQUAL(5, devdef.hostpipe_mappings.size());
 
-//   CHECK_EQUAL(5, devdef.hostpipe_mappings.size());
+  CHECK(devdef.hostpipe_mappings[0].logical_name == "pipe_logical_name1");
+  CHECK(devdef.hostpipe_mappings[0].physical_name == "pipe_physical_name1");
+  CHECK(devdef.hostpipe_mappings[0].implement_in_csr);
+  CHECK(devdef.hostpipe_mappings[0].csr_address == "12345");
+  CHECK(!devdef.hostpipe_mappings[0].is_read);
+  CHECK(devdef.hostpipe_mappings[0].is_write);
+  CHECK(devdef.hostpipe_mappings[0].pipe_width == 4);
+  CHECK(devdef.hostpipe_mappings[0].pipe_depth == 10);
 
-//   CHECK(devdef.hostpipe_mappings[0].logical_name == "pipe_logical_name1");
-//   CHECK(devdef.hostpipe_mappings[0].physical_name == "pipe_physical_name1");
-//   CHECK(devdef.hostpipe_mappings[0].implement_in_csr);
-//   CHECK(devdef.hostpipe_mappings[0].csr_address == 12345);
+  CHECK(devdef.hostpipe_mappings[1].logical_name == "pipe_logical_name2");
+  CHECK(devdef.hostpipe_mappings[1].physical_name == "pipe_physical_name2");
+  CHECK(!devdef.hostpipe_mappings[1].implement_in_csr);
+  CHECK(devdef.hostpipe_mappings[1].csr_address == "12323");
+  CHECK(devdef.hostpipe_mappings[1].is_read);
+  CHECK(!devdef.hostpipe_mappings[1].is_write);
+  CHECK(devdef.hostpipe_mappings[1].pipe_width == 8);
+  CHECK(devdef.hostpipe_mappings[1].pipe_depth == 20);
 
-//   CHECK(devdef.hostpipe_mappings[1].logical_name == "pipe_logical_name2");
-//   CHECK(devdef.hostpipe_mappings[1].physical_name == "pipe_physical_name2");
-//   CHECK(!devdef.hostpipe_mappings[1].implement_in_csr);
-//   CHECK(devdef.hostpipe_mappings[1].csr_address == 12323);
+  CHECK(devdef.hostpipe_mappings[2].logical_name == "pipe_logical_name3");
+  CHECK(devdef.hostpipe_mappings[2].physical_name == "pipe_physical_name1");
+  CHECK(devdef.hostpipe_mappings[2].implement_in_csr);
+  CHECK(devdef.hostpipe_mappings[2].csr_address == "12313");
+  CHECK(!devdef.hostpipe_mappings[2].is_read);
+  CHECK(devdef.hostpipe_mappings[2].is_write);
+  CHECK(devdef.hostpipe_mappings[2].pipe_width == 4);
+  CHECK(devdef.hostpipe_mappings[2].pipe_depth == 10);
 
-//   CHECK(devdef.hostpipe_mappings[2].logical_name == "pipe_logical_name3");
-//   CHECK(devdef.hostpipe_mappings[2].physical_name == "pipe_physical_name1");
-//   CHECK(devdef.hostpipe_mappings[2].implement_in_csr);
-//   CHECK(devdef.hostpipe_mappings[2].csr_address == 12313);
+  CHECK(devdef.hostpipe_mappings[3].logical_name == "pipe_logical_name5");
+  CHECK(devdef.hostpipe_mappings[3].physical_name == "pipe_physical_name1");
+  CHECK(!devdef.hostpipe_mappings[3].implement_in_csr);
+  CHECK(devdef.hostpipe_mappings[3].csr_address == "12316");
+  CHECK(devdef.hostpipe_mappings[3].is_read);
+  CHECK(!devdef.hostpipe_mappings[3].is_write);
+  CHECK(devdef.hostpipe_mappings[3].pipe_width == 8);
+  CHECK(devdef.hostpipe_mappings[3].pipe_depth == 20);
 
-//   CHECK(devdef.hostpipe_mappings[3].logical_name == "pipe_logical_name1");
-//   CHECK(devdef.hostpipe_mappings[3].physical_name == "pipe_physical_name1");
-//   CHECK(!devdef.hostpipe_mappings[3].implement_in_csr);
-//   CHECK(devdef.hostpipe_mappings[3].csr_address == 12316);
-
-//   CHECK(devdef.hostpipe_mappings[4].logical_name == "pipe_logical_name1");
-//   CHECK(devdef.hostpipe_mappings[4].physical_name == "pipe_physical_name3");
-//   CHECK(!devdef.hostpipe_mappings[4].implement_in_csr);
-//   CHECK(devdef.hostpipe_mappings[4].csr_address == 12342);
-// }
+  CHECK(devdef.hostpipe_mappings[4].logical_name == "pipe_logical_name4");
+  CHECK(devdef.hostpipe_mappings[4].physical_name == "pipe_physical_name3");
+  CHECK(!devdef.hostpipe_mappings[4].implement_in_csr);
+  CHECK(devdef.hostpipe_mappings[4].csr_address == "12342");
+  CHECK(!devdef.hostpipe_mappings[4].is_read);
+  CHECK(devdef.hostpipe_mappings[4].is_write);
+  CHECK(devdef.hostpipe_mappings[4].pipe_width == 4);
+  CHECK(devdef.hostpipe_mappings[4].pipe_depth == 10);
+}

--- a/test/acl_device_op_test.cpp
+++ b/test/acl_device_op_test.cpp
@@ -277,6 +277,7 @@ TEST(device_op, conflict_type) {
 
   op = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, 0);
   CHECK(op);
+  assert(op != NULL);
 
   CHECK_EQUAL(ACL_CONFLICT_NONE, acl_device_op_conflict_type(op));
 
@@ -347,6 +348,7 @@ TEST(device_op, submit_action) {
   acl_device_op_t *op = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, 0);
   acl_commit_proposed_device_ops(&m_doq);
   CHECK(op);
+  assert(op != NULL);
 
   // Already submitted because committing nudges device opthe scheduler.
   CHECK_EQUAL(CL_SUBMITTED, op->status);
@@ -443,6 +445,7 @@ TEST(device_op, post_status) {
   CHECK(e);
 
   acl_device_op_t *op = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, e);
+  assert(op != NULL);
   CHECK_EQUAL(e, op->info.event);
 
   e->execution_status = CL_COMPLETE;
@@ -470,6 +473,7 @@ TEST(device_op, post_status) {
 
   cl_event e2 = clCreateUserEvent(m_context, 0);
   acl_device_op_t *op2 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, e2);
+  assert(op2 != NULL);
 
   op2->timestamp[CL_COMPLETE] = 13;
   op2->execution_status = -5;
@@ -496,6 +500,11 @@ TEST(device_op, err_status) {
   acl_device_op_t *op0 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, e);
   acl_device_op_t *op1 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, e);
   acl_device_op_t *op2 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, e);
+
+  assert(op0 != NULL);
+  assert(op1 != NULL);
+  assert(op2 != NULL);
+
   CHECK_EQUAL(e, op0->info.event);
   CHECK_EQUAL(e, op1->info.event);
   CHECK_EQUAL(e, op2->info.event);
@@ -593,6 +602,7 @@ TEST(device_op, exhaust) {
                                                   (unsigned)i)
                   : acl_propose_device_op(&m_doq, ACL_DEVICE_OP_NONE, e);
       CHECK(op);
+      assert(op != NULL);
       ops[i] = op;
       CHECK(op);
       acl_print_debug_msg(
@@ -847,6 +857,8 @@ TEST(device_op, prune) {
 
   acl_device_op_t *op0 = acl_propose_device_op(doq, ACL_DEVICE_OP_NONE, e0);
   acl_device_op_t *op1 = acl_propose_device_op(doq, ACL_DEVICE_OP_NONE, e0);
+  assert(op0 != NULL);
+  assert(op1 != NULL);
   acl_commit_proposed_device_ops(doq);
 
   CHECK_EQUAL(0, doq->first_live);
@@ -938,6 +950,7 @@ TEST(device_op, inter_group_blocking) {
   acl_device_op_t *op0 =
       acl_propose_device_op(&m_doq, ACL_DEVICE_OP_MEM_TRANSFER_READ, 0);
   CHECK(op0);
+  assert(op0 != NULL);
   acl_commit_proposed_device_ops(&m_doq);
 
   acl_device_op_t *op1 =
@@ -945,6 +958,8 @@ TEST(device_op, inter_group_blocking) {
   acl_device_op_t *op3 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_KERNEL, 0);
   CHECK(op1);
   CHECK(op3);
+  assert(op1 != NULL);
+  assert(op3 != NULL);
   acl_commit_proposed_device_ops(&m_doq);
 
   acl_update_device_op_queue(&m_doq);
@@ -1002,6 +1017,7 @@ TEST(device_op, inter_group_all_conflict_types) {
   // where it belongs.
 
   acl_device_op_t *k00 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_KERNEL, 0);
+  assert(k00 != NULL);
   acl_commit_proposed_device_ops(&m_doq);
   CHECK_EQUAL(CL_SUBMITTED, k00->status);
 
@@ -1011,7 +1027,9 @@ TEST(device_op, inter_group_all_conflict_types) {
 
   acl_device_op_t *p1 =
       acl_propose_device_op(&m_doq, ACL_DEVICE_OP_REPROGRAM, 0);
+  assert(p1 != NULL);
   acl_device_op_t *k10 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_KERNEL, 0);
+  assert(k10 != NULL);
   acl_commit_proposed_device_ops(&m_doq);
 
   CHECK_EQUAL(CL_RUNNING, k00->status);
@@ -1019,6 +1037,7 @@ TEST(device_op, inter_group_all_conflict_types) {
   CHECK_EQUAL(CL_QUEUED, k10->status);
 
   acl_device_op_t *k11 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_KERNEL, 0);
+  assert(k11 != NULL);
   acl_commit_proposed_device_ops(&m_doq);
 
   CHECK_EQUAL(CL_RUNNING, k00->status);
@@ -1053,10 +1072,13 @@ TEST(device_op, inter_group_concurrent_kernels) {
 
   acl_device_op_t *op0 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_KERNEL, 0);
   CHECK(op0);
+  assert(op0 != NULL);
   acl_commit_proposed_device_ops(&m_doq);
 
   acl_device_op_t *op1 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_KERNEL, 0);
   acl_device_op_t *op2 = acl_propose_device_op(&m_doq, ACL_DEVICE_OP_KERNEL, 0);
+  assert(op1 != NULL);
+  assert(op2 != NULL);
   CHECK(op1);
   CHECK(op2);
   acl_commit_proposed_device_ops(&m_doq);
@@ -1397,6 +1419,9 @@ TEST(device_op, full_duplex) {
   acl_commit_proposed_device_ops(&m_doq);
   acl_device_op_t *op_rw =
       acl_propose_device_op(&m_doq, ACL_DEVICE_OP_MEM_TRANSFER_COPY, event);
+  assert(op_read != NULL);
+  assert(op_write != NULL);
+  assert(op_rw != NULL);
   acl_commit_proposed_device_ops(&m_doq);
   acl_update_device_op_queue(&m_doq);
   CHECK_EQUAL(CL_SUBMITTED, op_read->status);
@@ -1426,9 +1451,11 @@ TEST(device_op, full_duplex) {
   acl_set_device_op_execution_status(op_rw, CL_RUNNING);
   op_read =
       acl_propose_device_op(&m_doq, ACL_DEVICE_OP_MEM_TRANSFER_READ, event);
+  assert(op_read != NULL);
   acl_commit_proposed_device_ops(&m_doq);
   op_write =
       acl_propose_device_op(&m_doq, ACL_DEVICE_OP_MEM_TRANSFER_WRITE, event);
+  assert(op_write != NULL);
   acl_commit_proposed_device_ops(&m_doq);
   acl_update_device_op_queue(&m_doq);
   CHECK_EQUAL(CL_RUNNING, op_rw->status);
@@ -1480,8 +1507,10 @@ TEST(device_op, multi_device_rw_conflict) {
         event = &myevents[k];
 
         acl_device_op_t *op1 = acl_propose_device_op(&m_doq, ops[i], event);
+        assert(op1 != NULL);
         acl_commit_proposed_device_ops(&m_doq);
         acl_device_op_t *op2 = acl_propose_device_op(&m_doq, ops[j], event);
+        assert(op2 != NULL);
         acl_commit_proposed_device_ops(&m_doq);
         acl_update_device_op_queue(&m_doq);
         CHECK_EQUAL(CL_SUBMITTED, op1->status);


### PR DESCRIPTION
1. Support program scope hostpipe, CSR pipe and non-CSR pipe.
2. Register program scoped hostpipes during program creation.
3. Create new command op and device op for the hostpipe read and write
4. Unit test is only for the auto-discovery string. Other unit tests will be added through other PR.
5. Most of the Klocwork issues are the existing issues but listed as the new issues due to I modified the source code for the test, but I will attempt to fix all of them.
6. More error checking needs to be done. Will add through a new PR.