### PR TITLE
Fix kernel id - CSR address mapping issue

### DIFF
--- a/include/acl_hal.h
+++ b/include/acl_hal.h
@@ -247,6 +247,10 @@ typedef struct {
                                            const std::string &signal_name,
                                            unsigned int &finish_counter);
 
+  void (*simulation_set_kernel_cra_address_map)(
+      unsigned int physical_device_id,
+      const std::vector<uintptr_t> &kernel_csr_address_map);
+
   size_t (*read_csr)(unsigned int physical_device_id, uintptr_t offset,
                      void *ptr, size_t size);
 

--- a/include/acl_hal_mmd.h
+++ b/include/acl_hal_mmd.h
@@ -149,6 +149,12 @@ typedef struct {
   // accounted and returned in a subsequent invocation of this function.
   void (*aocl_mmd_simulation_streaming_kernel_done)(
       int handle, const std::string &signal_name, unsigned int &finish_counter);
+
+  // Pass kernel-id to csr-address mapping read from the current binary
+  // to the simulation runtime, so that it can detect which start register
+  // has been written by the runtime.
+  void (*aocl_mmd_simulation_set_kernel_cra_address_map)(
+      int handle, const std::vector<uintptr_t> &kernel_csr_address_map);
 } acl_mmd_dispatch_t;
 
 typedef struct {

--- a/src/acl_hal_mmd.cpp
+++ b/src/acl_hal_mmd.cpp
@@ -161,6 +161,10 @@ void acl_hal_mmd_simulation_streaming_kernel_done(
     unsigned int physical_device_id, const std::string &kernel_name,
     unsigned int &finish_counter);
 
+void acl_hal_mmd_simulation_set_kernel_cra_address_map(
+    unsigned int physical_device_id,
+    const std::vector<uintptr_t> &kernel_csr_address_map);
+
 size_t acl_hal_mmd_read_csr(unsigned int physical_device_id, uintptr_t offset,
                             void *ptr, size_t size);
 
@@ -360,8 +364,9 @@ static acl_hal_t acl_hal_mmd = {
     acl_hal_mmd_shared_alloc,                     // shared_alloc
     acl_hal_mmd_simulation_streaming_kernel_start, // simulation_streaming_kernel_start
     acl_hal_mmd_simulation_streaming_kernel_done, // simulation_streaming_kernel_done
-    acl_hal_mmd_read_csr,                         // read_csr
-    acl_hal_mmd_write_csr,                        // write_csr
+    acl_hal_mmd_simulation_set_kernel_cra_address_map, // simulation_set_kernel_cra_address_map
+    acl_hal_mmd_read_csr,                              // read_csr
+    acl_hal_mmd_write_csr,                             // write_csr
 };
 
 // This will contain the device physical id to tell us which device across all
@@ -2863,6 +2868,14 @@ void acl_hal_mmd_simulation_streaming_kernel_done(
   device_info[physical_device_id]
       .mmd_dispatch->aocl_mmd_simulation_streaming_kernel_done(
           device_info[physical_device_id].handle, kernel_name, finish_counter);
+}
+
+void acl_hal_mmd_simulation_set_kernel_cra_address_map(
+    unsigned int physical_device_id,
+    const std::vector<uintptr_t> &kernel_csr_address_map) {
+  device_info[physical_device_id]
+      .mmd_dispatch->aocl_mmd_simulation_set_kernel_cra_address_map(
+          device_info[physical_device_id].handle, kernel_csr_address_map);
 }
 
 size_t acl_hal_mmd_read_csr(unsigned int physical_device_id, uintptr_t offset,

--- a/src/acl_kernel_if.cpp
+++ b/src/acl_kernel_if.cpp
@@ -921,15 +921,21 @@ int acl_kernel_if_update(const acl_device_def_autodiscovery_t &devdef,
     // The Kernel CSR registers
     // The new and improved config ROM give us the address *offsets* from
     // the first kernel CSR, and the range of each kernel CSR.
+    std::vector<uintptr_t> kernel_csr_address_map;
     for (unsigned ii = 0; ii < devdef.accel.size(); ++ii) {
       kern->accel_csr[ii].address =
           OFFSET_KERNEL_CRA + devdef.hal_info[ii].csr.address;
       kern->accel_csr[ii].bytes = devdef.hal_info[ii].csr.num_bytes;
+      kernel_csr_address_map.push_back(kern->accel_csr[ii].address);
 
       ACL_KERNEL_IF_DEBUG_MSG(
           kern, "Kernel_%s CSR { 0x%08" PRIxPTR ", 0x%08" PRIxPTR " }\n",
           devdef.accel[ii].iface.name.c_str(), kern->accel_csr[ii].address,
           kern->accel_csr[ii].bytes);
+    }
+    if (acl_platform.offline_mode == ACL_CONTEXT_MPSIM) {
+      acl_get_hal()->simulation_set_kernel_cra_address_map(
+          kern->physical_device_id, kernel_csr_address_map);
     }
 
     // The Kernel performance monitor registers


### PR DESCRIPTION
Currently in simulation we need to match CSR address with kernel id in order to know which start register the runtime is writing into and set the corresponding start signal in the simulation control BFM. This change sends the kernel id CSR address mapping information to the simulation runtime through a new simulation MMD function.