### PR TITLE
Modify USM device allocation information returned by clGetDeviceInfo

### DIFF
--- a/src/acl_device.cpp
+++ b/src/acl_device.cpp
@@ -533,9 +533,16 @@ CL_API_ENTRY cl_int CL_API_CALL clGetDeviceInfoIntelFPGA(
     if (param_name == CL_DEVICE_HOST_MEM_CAPABILITIES_INTEL) {
       capabilities = device->def.host_capabilities;
     } else if (param_name == CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL) {
-      // Device allocations are supported for all legacy devices
-      // Device allocations managed by runtime in legacy devices
-      capabilities = ACL_MEM_CAPABILITY_SUPPORTED;
+      if (acl_platform.offline_mode == ACL_CONTEXT_MPSIM) {
+        // Device allocations are not supported in IPA flow which
+        // currently runs in simulation only. Return true device
+        // allocation capabilities in this case.
+        capabilities = device->def.device_capabilities;
+      } else {
+        // IPA is not supported with hardware flow currently, and
+        // device allocations are supported for all legacy devices
+        capabilities = ACL_MEM_CAPABILITY_SUPPORTED;
+      }
     } else {
       capabilities = device->def.shared_capabilities;
     }

--- a/src/acl_usm.cpp
+++ b/src/acl_usm.cpp
@@ -238,6 +238,14 @@ clDeviceMemAllocINTEL(cl_context context, cl_device_id device,
               "Memory buffer size is larger than max size supported by device");
   }
 
+  if (!acl_usm_has_access_capability(device,
+                                     CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL)) {
+    BAIL_INFO(
+        CL_INVALID_OPERATION, context,
+        "Device does not support device Unified Shared Memory allocations: " +
+            device->def.autodiscovery_def.name);
+  }
+
   // Spec allows for power of 2 allignment.
   // For now, we only allow alignment to ACL_MEM_ALIGN.
   // Over align all allocations to ACL_MEM_ALIGN.


### PR DESCRIPTION
According to [USM extension spec](https://registry.khronos.org/OpenCL/extensions/intel/cl_intel_unified_shared_memory.html#_device_allocations), clDeviceMemAllocINTEL will return `NULL` and `CL_INVALID_OPERATION` status if the device has property `CL_DEVICE_DEVICE_MEM_CAPABILITIES_INTEL` equal to 0. Before, the runtime always return 1 for device allocation capabilities as all legacy devices support device allocations. This is no longer true in IP Authoring flow.