### PR TITLE
Support AVALON_MM CSR hostpipe

### DIFF
--- a/include/acl.h
+++ b/include/acl.h
@@ -535,6 +535,13 @@ struct acl_hostpipe_mapping {
   bool is_write;
   unsigned pipe_width;
   unsigned pipe_depth;
+
+  // Matches the protocol_name enum in
+  // https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/ext/intel/experimental/pipe_properties.hpp
+  // Set a default value in case it's missing.
+
+  int protocol = -1; // avalon_streaming = 0, avalon_streaming_uses_ready = 1
+                     // avalon_mm = 2, avalon_mm_uses_ready = 3
 };
 
 // Part of acl_device_def_t where members are populated from the information

--- a/include/acl_types.h
+++ b/include/acl_types.h
@@ -331,6 +331,12 @@ typedef struct host_pipe_struct {
   // non-CSR program hostpipe
   std::string csr_address;
 
+  // Matches the protocol_name enum in
+  // https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/ext/intel/experimental/pipe_properties.hpp
+  // Set a default value in case it's missing.
+  int protocol = -1; // avalon_streaming = 0, avalon_streaming_uses_ready = 1
+                     // avalon_mm = 2, avalon_mm_uses_ready = 3
+
 } host_pipe_t;
 
 // The device-specific information about a program.

--- a/src/acl_auto_configure.cpp
+++ b/src/acl_auto_configure.cpp
@@ -661,6 +661,13 @@ static bool read_hostpipe_mappings(
                            counters) &&
         read_uint_counters(config_str, curr_pos, mapping.pipe_depth, counters);
 
+    // Start from 2024.0, there is a new field called protocol in the
+    // auto-discovery string
+    if (result && counters.back() > 0) {
+      result = result && read_int_counters(config_str, curr_pos,
+                                           mapping.protocol, counters);
+    }
+
     hostpipe_mappings.emplace_back(mapping);
 
     while (result && counters.back() > 0) {

--- a/src/acl_program.cpp
+++ b/src/acl_program.cpp
@@ -1363,6 +1363,7 @@ l_register_hostpipes_to_program(acl_device_program_info_t *dev_prog,
         return CL_INVALID_VALUE;
       }
     }
+    host_pipe_info.protocol = hostpipe.protocol;
     acl_mutex_init(&(host_pipe_info.m_lock), NULL);
     // The following property is not used by the program scoped hostpipe but we
     // don't want to leave it uninitialized

--- a/test/acl_auto_configure_test.cpp
+++ b/test/acl_auto_configure_test.cpp
@@ -1490,14 +1490,14 @@ TEST(auto_configure, cra_ring_root_exist) {
 
 TEST(auto_configure, hostpipe_mappings) {
   const std::string config_str{
-      "23 66 " RANDOM_HASH
+      "23 71 " RANDOM_HASH
       " pac_a10 0 1 13 DDR 2 2 24 1 2 0 4294967296 4294967296 8589934592 0 - 0 "
-      "0 0 0 0 0 1 5 8 pipe_logical_name1 pipe_physical_name1 1 12345 0 1 4 10 "
-      "pipe_logical_name2 pipe_physical_name2 0 12323 1 0 8 20 "
-      "pipe_logical_name3 "
-      "pipe_physical_name1 1 12313 0 1 4 10 pipe_logical_name5 "
-      "pipe_physical_name1 0 "
-      "12316 1 0 8 20 pipe_logical_name4 pipe_physical_name3 0 12342 0 1 4 10 "
+      "0 0 0 0 0 1 5 9 " // 5 Hostpipes, 9 in each mapping
+      "pipe_logical_name1 pipe_physical_name1 1 12345 0 1 4 10 0 "
+      "pipe_logical_name2 pipe_physical_name2 0 12323 1 0 8 20 1 "
+      "pipe_logical_name3 pipe_physical_name1 1 12313 0 1 4 10 2 "
+      "pipe_logical_name5 pipe_physical_name1 0 12316 1 0 8 20 3 "
+      "pipe_logical_name4 pipe_physical_name3 0 12342 0 1 4 10 3 "
       "3 90 "
       "_ZTS3CRCILi0EE 512 256 1 0 0 1 0 1 0 9 6 0 0 8 1 0 0 6 2 1 8 1024 0 3 6 "
       "0 0 8 1 0 0 6 0 0 8 1 0 0 6 0 0 8 1 0 0 6 2 1 8 1024 0 2 6 0 0 8 1 0 0 "
@@ -1531,6 +1531,7 @@ TEST(auto_configure, hostpipe_mappings) {
   CHECK(devdef.hostpipe_mappings[0].is_write);
   CHECK(devdef.hostpipe_mappings[0].pipe_width == 4);
   CHECK(devdef.hostpipe_mappings[0].pipe_depth == 10);
+  CHECK(devdef.hostpipe_mappings[0].protocol == 0);
 
   CHECK(devdef.hostpipe_mappings[1].logical_name == "pipe_logical_name2");
   CHECK(devdef.hostpipe_mappings[1].physical_name == "pipe_physical_name2");
@@ -1540,6 +1541,7 @@ TEST(auto_configure, hostpipe_mappings) {
   CHECK(!devdef.hostpipe_mappings[1].is_write);
   CHECK(devdef.hostpipe_mappings[1].pipe_width == 8);
   CHECK(devdef.hostpipe_mappings[1].pipe_depth == 20);
+  CHECK(devdef.hostpipe_mappings[1].protocol == 1);
 
   CHECK(devdef.hostpipe_mappings[2].logical_name == "pipe_logical_name3");
   CHECK(devdef.hostpipe_mappings[2].physical_name == "pipe_physical_name1");
@@ -1549,6 +1551,7 @@ TEST(auto_configure, hostpipe_mappings) {
   CHECK(devdef.hostpipe_mappings[2].is_write);
   CHECK(devdef.hostpipe_mappings[2].pipe_width == 4);
   CHECK(devdef.hostpipe_mappings[2].pipe_depth == 10);
+  CHECK(devdef.hostpipe_mappings[2].protocol == 2);
 
   CHECK(devdef.hostpipe_mappings[3].logical_name == "pipe_logical_name5");
   CHECK(devdef.hostpipe_mappings[3].physical_name == "pipe_physical_name1");
@@ -1558,6 +1561,7 @@ TEST(auto_configure, hostpipe_mappings) {
   CHECK(!devdef.hostpipe_mappings[3].is_write);
   CHECK(devdef.hostpipe_mappings[3].pipe_width == 8);
   CHECK(devdef.hostpipe_mappings[3].pipe_depth == 20);
+  CHECK(devdef.hostpipe_mappings[3].protocol == 3);
 
   CHECK(devdef.hostpipe_mappings[4].logical_name == "pipe_logical_name4");
   CHECK(devdef.hostpipe_mappings[4].physical_name == "pipe_physical_name3");
@@ -1567,4 +1571,5 @@ TEST(auto_configure, hostpipe_mappings) {
   CHECK(devdef.hostpipe_mappings[4].is_write);
   CHECK(devdef.hostpipe_mappings[4].pipe_width == 4);
   CHECK(devdef.hostpipe_mappings[4].pipe_depth == 10);
+  CHECK(devdef.hostpipe_mappings[4].protocol == 3);
 }


### PR DESCRIPTION
1. Parse new protocol information from the compiler.
2. Skip read/write read&valid signal for AVALON_MM