### PR TITLE
Remove simulator device from offline devices

### DIFF
--- a/src/acl_globals.cpp
+++ b/src/acl_globals.cpp
@@ -115,7 +115,7 @@ const char *acl_get_offline_device_user_setting(int *use_offline_only_ret) {
     }
     if (setting) {
       use_offline_only = ACL_CONTEXT_MPSIM;
-      result = setting;
+      result = 0;
     }
   }
 

--- a/src/acl_hal_mmd.cpp
+++ b/src/acl_hal_mmd.cpp
@@ -1178,27 +1178,18 @@ void l_close_device(unsigned int physical_device_id,
 
 static acl_mmd_dispatch_t *get_msim_mmd_layer() {
 #ifdef _WIN32
-
   const char *acl_root_dir = acl_getenv("INTELFPGAOCLSDKROOT");
   info_assert(acl_root_dir,
               "INTELFPGAOCLSDKROOT environment variable is missing!");
-  const std::string mmd_lib_name_aoc_str =
+  const std::string mmd_lib_name_str =
       std::string(acl_root_dir) + "\\host\\windows64\\bin\\aoc_cosim_mmd.dll";
-  const std::string mmd_lib_name_ipa_str =
-      std::string(acl_root_dir) + "\\host\\windows64\\bin\\ipa_cosim_mmd.dll";
 
-  const char *mmd_lib_name_aoc = mmd_lib_name_aoc_str.c_str();
-  const char *mmd_lib_name_ipa = mmd_lib_name_ipa_str.c_str();
+  const char *mmd_lib_name = mmd_lib_name_str.c_str();
   const char *sym_name = "msim_mmd_layer";
 #else
-  const char *mmd_lib_name_aoc = "libaoc_cosim_mmd.so";
-  const char *mmd_lib_name_ipa = "libipa_cosim_mmd.so";
+  const char *mmd_lib_name = "libaoc_cosim_mmd.so";
   const char *sym_name = "msim_mmd_layer";
 #endif
-
-  const char *ipa_simulator = acl_getenv("ACL_IPA_SIM");
-  const char *mmd_lib_name =
-      ipa_simulator ? mmd_lib_name_ipa : mmd_lib_name_aoc;
 
   char *error_msg = nullptr;
   auto *mmd_lib = my_dlopen(mmd_lib_name, &error_msg);


### PR DESCRIPTION
Simulator device will now be initialized in the same fashion as hardware devices,
during `l_initialize_devices`. This can be done as we now load simulator device
global memory configuration from the correct autodiscovery string generated by
the system integrator as introduced by commit https://github.com/intel/fpga-runtime-for-opencl/commit/d57cedc9fa35d2efba22892e0d3e715481db09d3.