### PR TITLE
Delay erasing context from contexts_set during `acl_idle_update`

### DIFF
--- a/include/acl_types.h
+++ b/include/acl_types.h
@@ -1027,6 +1027,10 @@ typedef struct _cl_context {
   // Fix re-entrancy of clReleaseContext.
   int is_being_freed;
 
+  // Is this context in the middle of an idle update?
+  // Fix erase while traverse of contexts_set
+  int is_being_updated;
+
   ////////////////////////////
   // Behaviour switches dependent on compiler mode
   //


### PR DESCRIPTION
Fixes issue where context is being deleted from `contexts_set` while traversing through the same `context_set`, causing undefined behaviour and sometimes crash in `acl_idle_update`.