### PR TITLE
Add support for hostpipe sideband signals.

### DIFF
--- a/include/acl.h
+++ b/include/acl.h
@@ -544,6 +544,25 @@ struct acl_hostpipe_mapping {
                      // avalon_mm = 2, avalon_mm_uses_ready = 3
 };
 
+// Mapping of sideband signals to logical pipe
+
+struct acl_sideband_signal_mapping {
+  std::string logical_name;
+  unsigned port_identifier;
+  unsigned port_offset;   // bit
+  unsigned sideband_size; // bit
+};
+
+// Must match the definition in the compiler
+// Analysis/FPGAAnalysis/Utils/StreamParameters.h
+enum signal_type {
+  SignalUnknown = -1,
+  AvalonData = 0,
+  AvalonSop = 1,
+  AvalonEop = 2,
+  AvalonEmpty = 3
+};
+
 // Part of acl_device_def_t where members are populated from the information
 // in the autodiscovery string. This will get updated every time the device
 // is programmed with a new device binary as the new binary would contain a
@@ -570,6 +589,7 @@ typedef struct acl_device_def_autodiscovery_t {
       true; // Set the default value to true for backwards compatibility flows.
 
   std::vector<acl_hostpipe_mapping> hostpipe_mappings;
+  std::vector<acl_sideband_signal_mapping> sideband_signal_mappings;
 } acl_device_def_autodiscovery_t;
 
 typedef struct acl_device_def_t {

--- a/include/acl_hal.h
+++ b/include/acl_hal.h
@@ -265,6 +265,42 @@ typedef struct {
       unsigned int physical_device_id, const char *interface_name,
       const void *host_addr, size_t dev_addr, size_t size);
 
+  /// Simulation only mmd call as of 2024.1
+  /// Return the sideband signal buffer corresponding to the side band signal
+  /// port identifier
+  void *(*hostchannel_get_sideband_buffer)(unsigned int physical_device_id,
+                                           unsigned int port_name,
+                                           int channel_handle,
+                                           size_t *buffer_size, int *status);
+
+  /// Pull read_size of sideband data from the device into host_buffer, WITHOUT
+  /// acknowledge
+  size_t (*hostchannel_sideband_pull_no_ack)(unsigned int physical_device_id,
+                                             unsigned int port_name,
+                                             int channel_handle,
+                                             void *host_buffer,
+                                             size_t read_size, int *status);
+
+  /// Push write_size of sideband data to the device from host_buffer, WITHOUT
+  /// acknowledge
+  size_t (*hostchannel_sideband_push_no_ack)(unsigned int physical_device_id,
+                                             unsigned int port_name,
+                                             int channel_handle,
+                                             const void *host_buffer,
+                                             size_t write_size, int *status);
+
+  /// Pull read_size of data from the device into host_buffer, WITHOUT
+  /// acknowledge
+  size_t (*hostchannel_pull_no_ack)(unsigned int physical_device_id,
+                                    int channel_handle, void *host_buffer,
+                                    size_t read_size, int *status);
+
+  /// Push write_size of data to the device from host_buffer, WITHOUT
+  /// acknowledge
+  size_t (*hostchannel_push_no_ack)(unsigned int physical_device_id,
+                                    int channel_handle, const void *host_buffer,
+                                    size_t write_size, int *status);
+
 } acl_hal_t;
 
 /// Linked list of MMD library names to load.

--- a/include/acl_hal_mmd.h
+++ b/include/acl_hal_mmd.h
@@ -269,6 +269,16 @@ typedef struct {
   int (*aocl_mmd_simulation_device_global_interface_write)(
       int handle, const char *interface_name, const void *host_addr,
       size_t dev_addr, size_t size);
+
+  // Return the side band signal buffer corresponding to the side band signal
+  // port identifier Get a pointer to the mmd buffer for the host channel
+  // Simulation only mmd call as of 2024.1. HW MMD developer needs to implement
+  // this function in the future To support hostpipe sideband signals.
+  void *(*aocl_mmd_hostchannel_get_sideband_buffer)(int handle, int channel,
+                                                    int port_id,
+                                                    size_t *buffer_size,
+                                                    int *status);
+
 } acl_mmd_dispatch_t;
 
 typedef struct {

--- a/include/acl_types.h
+++ b/include/acl_types.h
@@ -295,6 +295,12 @@ typedef struct host_op_struct {
   size_t m_size_sent;
 } host_op_t;
 
+struct sideband_signal_t {
+  unsigned port_identifier; // matches enum signal_type in acl.h
+  unsigned port_offset;     // in bit
+  unsigned side_band_size;  // in bit
+};
+
 typedef struct host_pipe_struct {
   // The handle to the device needed for mmd call
   unsigned int m_physical_device_id;
@@ -336,6 +342,12 @@ typedef struct host_pipe_struct {
   // Set a default value in case it's missing.
   int protocol = -1; // avalon_streaming = 0, avalon_streaming_uses_ready = 1
                      // avalon_mm = 2, avalon_mm_uses_ready = 3
+
+  // Number of sideband signals. Exclude data port.
+  unsigned num_side_band_signals = 0;
+
+  // Sideband signals vector
+  std::vector<sideband_signal_t> side_band_signals_vector;
 
 } host_pipe_t;
 
@@ -617,7 +629,7 @@ typedef struct {
       const char *logical_name; // Use char* instead string here due to a
                                 // compilation error from acl_command_info_t
                                 // constructor malloc related
-    } host_pipe_info;
+    } host_pipe_dynamic_info;
 
     struct {
       // Used for device global ops


### PR DESCRIPTION
1. Parsed the new autodiscovery information, and record the side band signal information in the runtime host pipe struct
    
 2. Upon writing to the host pipes, parse the data packet received from SYCL into a data portion and individual side band signals using the offset information (do the opposite for reading: construct the data packet from the data and individual side band signals)

 3. Added call(s) to aocl_mmd_hostchannel_get_sideband_buffer when pushing/pulling packets with side band signals, write to/read from this buffer with the side band signal values.
    
 4. Acknowledge the read/write after all sideband signals and data finished read/write.