### PR TITLE
Update fuzz-test.yml with the correct permission.

### DIFF
--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -4,7 +4,7 @@ name: Runtime Fuzz Testing
 # https://github.com/ossf/scorecard/blob/2ef20f17fb2e64147c83440cd2c769653454015a/docs/checks.md#token-permissions
 permissions:
   # top-level permissions must be defined for security reasons.
-  contents: read
+  packages: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
https://github.com/intel/fpga-runtime-for-opencl/pull/338 introduced this regression when trying to add the missing top level permission. By setting content=read somehow make the token cannot access the package and caused this [failure](https://github.com/intel/fpga-runtime-for-opencl/actions/runs/8621042571).

Tests passed now: https://github.com/intel/fpga-runtime-for-opencl/actions/runs/8621418232/job/23630210788?pr=352