### PR TITLE
Update aocl_mmd.h version to 2024.2

### DIFF
--- a/include/MMD/aocl_mmd.h
+++ b/include/MMD/aocl_mmd.h
@@ -8,22 +8,23 @@
 extern "C" {
 #endif
 
-/* Support for memory mapped ACL devices.
+/**
+ *  Support for memory mapped ACL devices.
  *
- * Typical API lifecycle, from the perspective of the caller.
+ *  Typical API lifecycle, from the perspective of the caller.
  *
- *    1. aocl_mmd_open must be called first, to provide a handle for further
- *    operations.
+ *     1. aocl_mmd_open must be called first, to provide a handle for further
+ *     operations.
  *
- *    2. The interrupt and status handlers must be set.
+ *     2. The interrupt and status handlers must be set.
  *
- *    3. Read and write operations are performed.
+ *     3. Read and write operations are performed.
  *
- *    4. aocl_mmd_close may be called to shut down the device. No further
- *    operations are permitted until a subsequent aocl_mmd_open call.
+ *     4. aocl_mmd_close may be called to shut down the device. No further
+ *     operations are permitted until a subsequent aocl_mmd_open call.
  *
- * aocl_mmd_get_offline_info can be called anytime including before
- * open. aocl_mmd_get_info can be called anytime between open and close.
+ *  aocl_mmd_get_offline_info can be called anytime including before
+ *  open. aocl_mmd_get_info can be called anytime between open and close.
  */
 
 #ifndef AOCL_MMD_CALL
@@ -42,53 +43,56 @@ extern "C" {
 #endif
 #endif
 
-/* The MMD API's version - the runtime expects this string when
- * AOCL_MMD_VERSION is queried. This changes only if the API has changed */
-#define AOCL_MMD_VERSION_STRING "20.3"
+/**
+ *  The MMD API's version - the runtime expects this string when
+ *  AOCL_MMD_VERSION is queried. This changes only if the API has changed */
+#define AOCL_MMD_VERSION_STRING "2024.2"
 
-/* Memory types that can be supported - bitfield. Other than physical memory
- * these types closely align with the OpenCL SVM types.
+/**
+ *  Memory types that can be supported - bitfield. Other than physical memory
+ *  these types closely align with the OpenCL SVM types.
  *
- * AOCL_MMD_PHYSICAL_MEMORY - The vendor interface includes IP to communicate
- * directly with physical memory such as DDR, QDR, etc.
+ *  AOCL_MMD_PHYSICAL_MEMORY - The vendor interface includes IP to communicate
+ *  directly with physical memory such as DDR, QDR, etc.
  *
- * AOCL_MMD_SVM_COARSE_GRAIN_BUFFER - The vendor interface includes support for
- * caching SVM pointer data and requires explicit function calls from the user
- * to synchronize the cache between the host processor and the FPGA. This level
- * of SVM is not currently supported by Altera except as a subset of
- * SVM_FINE_GAIN_SYSTEM support.
+ *  AOCL_MMD_SVM_COARSE_GRAIN_BUFFER - The vendor interface includes support for
+ *  caching SVM pointer data and requires explicit function calls from the user
+ *  to synchronize the cache between the host processor and the FPGA. This level
+ *  of SVM is not currently supported by Altera except as a subset of
+ *  SVM_FINE_GAIN_SYSTEM support.
  *
- * AOCL_MMD_SVM_FINE_GRAIN_BUFFER - The vendor interface includes support for
- * caching SVM pointer data and requires additional information from the user
- * and/or host runtime that can be collected during pointer allocation in order
- * to synchronize the cache between the host processor and the FPGA. Once this
- * additional data is provided for an SVM pointer, the vendor interface handles
- * cache synchronization between the host processor & the FPGA automatically.
- * This level of SVM is not currently supported by Altera except as a subset
- * of SVM_FINE_GRAIN_SYSTEM support.
+ *  AOCL_MMD_SVM_FINE_GRAIN_BUFFER - The vendor interface includes support for
+ *  caching SVM pointer data and requires additional information from the user
+ *  and/or host runtime that can be collected during pointer allocation in order
+ *  to synchronize the cache between the host processor and the FPGA. Once this
+ *  additional data is provided for an SVM pointer, the vendor interface handles
+ *  cache synchronization between the host processor & the FPGA automatically.
+ *  This level of SVM is not currently supported by Altera except as a subset
+ *  of SVM_FINE_GRAIN_SYSTEM support.
  *
- * AOCL_MMD_SVM_FINE_GRAIN_SYSTEM - The vendor interface includes support for
- * caching SVM pointer data and does not require any additional information to
- * synchronize the cache between the host processor and the FPGA. The vendor
- * interface handles cache synchronization between the host processor & the
- * FPGA automatically for all SVM pointers. This level of SVM support is
- * currently under development by Altera and some features may not be fully
- * supported.
+ *  AOCL_MMD_SVM_FINE_GRAIN_SYSTEM - The vendor interface includes support for
+ *  caching SVM pointer data and does not require any additional information to
+ *  synchronize the cache between the host processor and the FPGA. The vendor
+ *  interface handles cache synchronization between the host processor & the
+ *  FPGA automatically for all SVM pointers. This level of SVM support is
+ *  currently under development by Altera and some features may not be fully
+ *  supported.
  */
 #define AOCL_MMD_PHYSICAL_MEMORY (1 << 0)
 #define AOCL_MMD_SVM_COARSE_GRAIN_BUFFER (1 << 1)
 #define AOCL_MMD_SVM_FINE_GRAIN_BUFFER (1 << 2)
 #define AOCL_MMD_SVM_FINE_GRAIN_SYSTEM (1 << 3)
 
-/* program modes - bitfield
+/**
+ *  program modes - bitfield
  *
- * AOCL_MMD_PROGRAM_PRESERVE_GLOBAL_MEM - preserve contents of global memory
- * when this bit is set to 1. If programming can't occur without preserving
- * global memory contents, the program function must fail, in which case the
- * runtime may re-invoke program with this bit set to 0, allowing programming
- * to occur even if doing so destroys global memory contents.
+ *  AOCL_MMD_PROGRAM_PRESERVE_GLOBAL_MEM - preserve contents of global memory
+ *  when this bit is set to 1. If programming can't occur without preserving
+ *  global memory contents, the program function must fail, in which case the
+ *  runtime may re-invoke program with this bit set to 0, allowing programming
+ *  to occur even if doing so destroys global memory contents.
  *
- * more modes are reserved for stacking on in the future
+ *  more modes are reserved for stacking on in the future
  */
 #define AOCL_MMD_PROGRAM_PRESERVE_GLOBAL_MEM (1 << 0)
 typedef int aocl_mmd_program_mode_t;
@@ -102,17 +106,18 @@ typedef struct {
 } aocl_mmd_timestamp_t;
 
 
-/* Defines the set of characteristics that can be probed about the board before
- * opening a device. The type of data returned by each is specified in
- * parentheses in the adjacent comment.
+/**
+ *  Defines the set of characteristics that can be probed about the board before
+ *  opening a device. The type of data returned by each is specified in
+ *  parentheses in the adjacent comment.
  *
- * AOCL_MMD_NUM_BOARDS and AOCL_MMD_BOARD_NAMES
- *   These two fields can be used to implement multi-device support. The MMD
- *   layer may have a list of devices it is capable of interacting with, each
- *   identified with a unique name. The length of the list should be returned
- *   in AOCL_MMD_NUM_BOARDS, and the names of these devices returned in
- *   AOCL_MMD_BOARD_NAMES. The OpenCL runtime will try to call aocl_mmd_open
- *   for each board name returned in AOCL_MMD_BOARD_NAMES.
+ *  AOCL_MMD_NUM_BOARDS and AOCL_MMD_BOARD_NAMES
+ *    These two fields can be used to implement multi-device support. The MMD
+ *    layer may have a list of devices it is capable of interacting with, each
+ *    identified with a unique name. The length of the list should be returned
+ *    in AOCL_MMD_NUM_BOARDS, and the names of these devices returned in
+ *    AOCL_MMD_BOARD_NAMES. The OpenCL runtime will try to call aocl_mmd_open
+ *    for each board name returned in AOCL_MMD_BOARD_NAMES.
  */
 typedef enum {
    AOCL_MMD_VERSION = 0,       /* Version of MMD (char*)*/
@@ -121,50 +126,56 @@ typedef enum {
    AOCL_MMD_VENDOR_NAME = 3,   /* Name of vendor (char*) */
    AOCL_MMD_VENDOR_ID = 4,     /* An integer ID for the vendor (int) */
    AOCL_MMD_USES_YIELD = 5,    /* 1 if yield must be called to poll hw (int) */
-   /* The following can be combined in a bit field:
-    * AOCL_MMD_PHYSICAL_MEMORY, AOCL_MMD_SVM_COARSE_GRAIN_BUFFER, AOCL_MMD_SVM_FINE_GRAIN_BUFFER, AOCL_MMD_SVM_FINE_GRAIN_SYSTEM.
-    * Prior to 14.1, all existing devices supported physical memory and no types of SVM memory, so this
-    * is the default when this operation returns '0' for board MMDs with a version prior to 14.1
+   /**
+    *  The following can be combined in a bit field:
+    *  AOCL_MMD_PHYSICAL_MEMORY, AOCL_MMD_SVM_COARSE_GRAIN_BUFFER,
+    *  AOCL_MMD_SVM_FINE_GRAIN_BUFFER, AOCL_MMD_SVM_FINE_GRAIN_SYSTEM.
+    *  Prior to 14.1, all existing devices supported physical memory and no types
+    *  of SVM memory, so this is the default when this operation returns '0' for
+    *  board MMDs with a version prior to 14.1.
     */
    AOCL_MMD_MEM_TYPES_SUPPORTED = 6,
 } aocl_mmd_offline_info_t;
 
 
-/** Possible capabilities to return from AOCL_MMD_*_MEM_CAPABILITIES query */
 /**
- * If not set allocation function is not supported, even if other capabilities are set.
+ *  Possible capabilities to return from AOCL_MMD_*_MEM_CAPABILITIES query
+ */
+/**
+ *  If not set allocation function is not supported, even if other capabilities
+ *  are set.
  */
 #define AOCL_MMD_MEM_CAPABILITY_SUPPORTED      (1 << 0)
 /**
- *   Supports atomic access to the memory by either the host or device.
+ *  Supports atomic access to the memory by either the host or device.
  */
 #define AOCL_MMD_MEM_CAPABILITY_ATOMIC         (1 << 1)
 /**
- * Supports concurrent access to the memory either by host or device if the
- * accesses are not on the same block. Block granularity is defined by
- * AOCL_MMD_*_MEM_CONCURRENT_GRANULARITY., blocks are aligned to this
- * granularity
+ *  Supports concurrent access to the memory either by host or device if the
+ *  accesses are not on the same block. Block granularity is defined by
+ *  AOCL_MMD_*_MEM_CONCURRENT_GRANULARITY., blocks are aligned to this
+ *  granularity
  */
 #define AOCL_MMD_MEM_CAPABILITY_CONCURRENT     (1 << 2)
 /**
- * Memory can be accessed by multiple devices at the same time.
+ *  Memory can be accessed by multiple devices at the same time.
  */
 #define AOCL_MMD_MEM_CAPABILITY_P2P            (1 << 3)
 
 
-/* Defines the set of characteristics that can be probed about the board after
- * opening a device. This can involve communication to the device
+/**
+ *  Defines the set of characteristics that can be probed about the board after
+ *  opening a device. This can involve communication to the device
  *
- * AOCL_MMD_NUM_KERNEL_INTERFACES - The number of kernel interfaces, usually 1
+ *  AOCL_MMD_NUM_KERNEL_INTERFACES - The number of kernel interfaces, usually 1
  *
- * AOCL_MMD_KERNEL_INTERFACES - the handle for each kernel interface.
- * param_value will have size AOCL_MMD_NUM_KERNEL_INTERFACES * sizeof int
+ *  AOCL_MMD_KERNEL_INTERFACES - the handle for each kernel interface.
+ *  param_value will have size AOCL_MMD_NUM_KERNEL_INTERFACES * sizeof int
  *
- * AOCL_MMD_PLL_INTERFACES - the handle for each pll associated with each
- * kernel interface. If a kernel interface is not clocked by acl_kernel_clk
- * then return -1
- *
- * */
+ *  AOCL_MMD_PLL_INTERFACES - the handle for each pll associated with each
+ *  kernel interface. If a kernel interface is not clocked by acl_kernel_clk
+ *  then return -1
+ */
 typedef enum {
    AOCL_MMD_NUM_KERNEL_INTERFACES = 1,  /* Number of Kernel interfaces (int) */
    AOCL_MMD_KERNEL_INTERFACES = 2,      /* Kernel interface (int*) */
@@ -190,278 +201,44 @@ typedef struct {
    unsigned long long int exception_type;
    void *user_private_info;
    size_t user_cb;
-}aocl_mmd_interrupt_info;
+} aocl_mmd_interrupt_info;
 
 typedef void (*aocl_mmd_interrupt_handler_fn)( int handle, void* user_data );
 typedef void (*aocl_mmd_device_interrupt_handler_fn)( int handle, aocl_mmd_interrupt_info* data_in, void* user_data );
 typedef void (*aocl_mmd_status_handler_fn)( int handle, void* user_data, aocl_mmd_op_t op, int status );
 
-
-/* Get information about the board using the enum aocl_mmd_offline_info_t for
- * offline info (called without a handle), and the enum aocl_mmd_info_t for
- * info specific to a certain board.
- * Arguments:
- *
- *   requested_info_id - a value from the aocl_mmd_offline_info_t enum
- *
- *   param_value_size - size of the param_value field in bytes. This should
- *     match the size of the return type expected as indicated in the enum
- *     definition. For example, the AOCL_MMD_TEMPERATURE returns a float, so
- *     the param_value_size should be set to sizeof(float) and you should
- *     expect the same number of bytes returned in param_size_ret.
- *
- *   param_value - pointer to the variable that will receive the returned info
- *
- *   param_size_ret - receives the number of bytes of data actually returned
- *
- * Returns: a negative value to indicate error.
+/**
+ *  Host channel port IDs
  */
-AOCL_MMD_CALL int aocl_mmd_get_offline_info(
-    aocl_mmd_offline_info_t requested_info_id,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_size_ret ) WEAK;
+typedef enum {
+   /**
+    *  Unknown port ID.
+    */
+   AOCL_MMD_HOSTCHANNEL_PORT_UNKNOWN = -1,
+   /**
+    *  Port ID for general data signal. This port ID is not to be used with
+    *  aocl_mmd_hostchannel_get_sideband_buffer(), to get the MMD buffer for
+    *  data port, use aocl_mmd_hostchannel_get_buffer() directly.
+    */
+   AOCL_MMD_HOSTCHANNEL_PORT_DATA = 0,
+   /**
+    *  Port ID for Avalon streaming interface startofpacket signal.
+    */
+   AOCL_MMD_HOSTCHANNEL_PORT_AVALON_SOP = 1,
+   /**
+    *  Port ID for Avalon streaming interface endofpacket signal.
+    */
+   AOCL_MMD_HOSTCHANNEL_PORT_AVALON_EOP = 2,
+   /**
+    *  Port ID for Avalon streaming interface empty signal.
+    */
+   AOCL_MMD_HOSTCHANNEL_PORT_AVALON_EMPTY = 3,
+} aocl_mmd_hostchannel_port_id_t;
 
-AOCL_MMD_CALL int aocl_mmd_get_info(
-    int handle,
-    aocl_mmd_info_t requested_info_id,
-    size_t param_value_size,
-    void* param_value,
-    size_t* param_size_ret ) WEAK;
 
-/* Open and initialize the named device.
- *
- * The name is typically one specified by the AOCL_MMD_BOARD_NAMES offline
- * info.
- *
- * Arguments:
- *    name - open the board with this name (provided as a C-style string,
- *           i.e. NUL terminated ASCII.)
- *
- * Returns: the non-negative integer handle for the board, otherwise a
- * negative value to indicate error. Upon receiving the error, the OpenCL
- * runtime will proceed to open other known devices, hence the MMD mustn't
- * exit the application if an open call fails.
+/**
+ *  Error values
  */
-AOCL_MMD_CALL int aocl_mmd_open(const char *name) WEAK;
-
-/* Close an opened device, by its handle.
- * Returns: 0 on success, negative values on error.
- */
-AOCL_MMD_CALL int aocl_mmd_close(int handle) WEAK;
-
-/* Set the interrupt handler for the opened device.
- * The interrupt handler is called whenever the client needs to be notified
- * of an asynchronous event signaled by the device internals.
- * For example, the kernel has completed or is stalled.
- *
- * Important: Interrupts from the kernel must be ignored until this handler is
- * set
- *
- * Arguments:
- *   fn - the callback function to invoke when a kernel interrupt occurs
- *   user_data - the data that should be passed to fn when it is called.
- *
- * Returns: 0 if successful, negative on error
- */
-AOCL_MMD_CALL int aocl_mmd_set_interrupt_handler( int handle, aocl_mmd_interrupt_handler_fn fn, void* user_data ) WEAK;
-
-/* Set the device interrupt handler for the opened device.
- * The device interrupt handler is called whenever the client needs to be notified
- * of a device event signaled by the device internals.
- * For example, an ECC error has been reported.
- *
- * Important: Interrupts from the device must be ignored until this handler is
- * set
- *
- * Arguments:
- *   fn - the callback function to invoke when a device interrupt occurs
- *   user_data - the data that should be passed to fn when it is called.
- *
- * Returns: 0 if successful, negative on error
- */
-AOCL_MMD_CALL int aocl_mmd_set_device_interrupt_handler( int handle, aocl_mmd_device_interrupt_handler_fn fn, void* user_data ) WEAK;
-
-/* Set the operation status handler for the opened device.
- * The operation status handler is called with
- *    status 0 when the operation has completed successfully.
- *    status negative when the operation completed with errors.
- *
- * Arguments:
- *   fn - the callback function to invoke when a status update is to be
- *   performed.
- *   user_data - the data that should be passed to fn when it is called.
- *
- * Returns: 0 if successful, negative on error
- */
-AOCL_MMD_CALL int aocl_mmd_set_status_handler( int handle, aocl_mmd_status_handler_fn fn, void* user_data ) WEAK;
-
-/* If AOCL_MMD_USES_YIELD is 1, this function is called when the host is idle
- * and hence possibly waiting for events to be processed by the device.
- * If AOCL_MMD_USES_YIELD is 0, this function is never called and the MMD is
- * assumed to provide status/event updates via some other execution thread
- * such as through an interrupt handler.
- *
- * Returns: non-zero if the yield function performed useful work such as
- * processing DMA transactions, 0 if there is no useful work to be performed
- *
- * NOTE: yield may be called continuously as long as it reports that it has useful work
- */
-AOCL_MMD_CALL int aocl_mmd_yield(int handle) WEAK;
-
-/* Read, write and copy operations on a single interface.
- * If op is NULL
- *    - Then these calls must block until the operation is complete.
- *    - The status handler is not called for this operation.
- *
- * If op is non-NULL, then:
- *    - These may be non-blocking calls
- *    - The status handler must be called upon completion, with status 0
- *    for success, and a negative value for failure.
- *
- * Arguments:
- *   op - the operation object used to track this operations progress
- *
- *   len - the size in bytes to transfer
- *
- *   src - the host buffer being read from
- *
- *   dst - the host buffer being written to
- *
- *   mmd_interface - the handle to the interface being accessed. E.g. To
- *   access global memory this handle will be whatever is returned by
- *   aocl_mmd_get_info when called with AOCL_MMD_MEMORY_INTERFACE.
- *
- *   offset/src_offset/dst_offset - the byte offset within the interface that
- *   the transfer will begin at.
- *
- * The return value is 0 if the operation launch was successful, and
- * negative otherwise.
- */
-AOCL_MMD_CALL int aocl_mmd_read(
-      int handle,
-      aocl_mmd_op_t op,
-      size_t len,
-      void* dst,
-      int mmd_interface, size_t offset ) WEAK;
-AOCL_MMD_CALL int aocl_mmd_write(
-      int handle,
-      aocl_mmd_op_t op,
-      size_t len,
-      const void* src,
-      int mmd_interface, size_t offset ) WEAK;
-AOCL_MMD_CALL int aocl_mmd_copy(
-      int handle,
-      aocl_mmd_op_t op,
-      size_t len,
-      int mmd_interface, size_t src_offset, size_t dst_offset ) WEAK;
-
-/* Host Channel create operation
- * Opens channel between host and kernel.
- *
- * Arguments:
- *   channel_name - name of channel to initialize. Same name as used in board_spec.xml
- *
- *   queue_depth - the size in bytes of pinned memory queue in system memory
- *
- *   direction - the direction of the channel
- *
- * The return value is negative if initialization was unsuccessful, and
- * positive otherwise. Positive return value is handle to the channel to be used for
- * subsequent calls for the channel.
- */
-AOCL_MMD_CALL int aocl_mmd_hostchannel_create(
-      int handle,
-      char *channel_name,
-      size_t queue_depth,
-      int direction) WEAK;
-
-/* Host Channel destroy operation
- * Closes channel between host and kernel.
- *
- * Arguments:
- *   channel - the handle to the channel to close, that was obtained with
- *             create channel
- *
- * The return value is 0 if the destroy was successful, and negative
- * otherwise.
- */
-AOCL_MMD_CALL int aocl_mmd_hostchannel_destroy(
-      int handle,
-      int channel) WEAK;
-
-/* Host Channel get buffer operation
- * Provide host with pointer to buffer they can access to write or
- * read from kernel, along with space or data available in the buffer
- * in bytes.
- *
- * Arguments:
- *   channel - the handle to the channel to get the buffer for
- *
- *   buffer_size - the address that this call will write the amount of
- *                 space or data that's available in the buffer,
- *                 depending on direction of the channel, in bytes
- *
- *   status - the address that this call will write to for result of this
- *            call. Value will be 0 for success, and negative otherwise
- *
- * The return value is the pointer to the buffer that host can write
- * to or read from. NULL if the status is negative.
- */
-AOCL_MMD_CALL void *aocl_mmd_hostchannel_get_buffer(
-      int handle,
-      int channel,
-      size_t *buffer_size,
-      int *status) WEAK;
-
-/* Host Channel acknowledge buffer operation
- * Acknowledge to the channel that the user has written or read data from
- * it. This will make the data or additional buffer space available to
- * write to or read from kernel.
- *
- * Arguments:
- *   channel - the handle to the channel that user is acknowledging
- *
- *   send_size - the size in bytes that the user is acknowledging
- *
- *   status - the address that this call will write to for result of this
- *            call. Value will be 0 for success, and negative otherwise
- *
- * The return value is equal to send_size if send_size was less than or
- * equal to the buffer_size from get buffer call. If send_size was
- * greater, then return value is the amount that was actually sent.
- */
-AOCL_MMD_CALL size_t aocl_mmd_hostchannel_ack_buffer(
-      int handle,
-      int channel,
-      size_t send_size,
-      int *status) WEAK;
-
-/* Program the device
- *
- * The host will guarantee that no operations are currently executing on the
- * device. That means the kernels will be idle and no read/write/copy
- * commands are active. Interrupts should be disabled and the FPGA should
- * be reprogrammed with the data from user_data which has size size. The host
- * will then call aocl_mmd_set_status_handler and aocl_mmd_set_interrupt_handler
- * again. At this point interrupts can be enabled.
- *
- * The new handle to the board after reprogram does not have to be the same as
- * the one before.
- *
- * Arguments:
- *   user_data - The binary contents of the fpga.bin file created during
- *   Quartus II compilation.
- *   size - the size in bytes of user_data
- *   program_mode - bit field for programming attributes. See
- *   aocl_mmd_program_mode_t definition
- *
- * Returns: the new non-negative integer handle for the board, otherwise a
- * negative value to indicate error.
- */
-AOCL_MMD_CALL int aocl_mmd_program( int handle, void * user_data, size_t size, aocl_mmd_program_mode_t program_mode) WEAK;
-
-/** Error values*/
 #define AOCL_MMD_ERROR_SUCCESS                 0
 #define AOCL_MMD_ERROR_INVALID_HANDLE         -1
 #define AOCL_MMD_ERROR_OUT_OF_MEMORY          -2
@@ -470,7 +247,9 @@ AOCL_MMD_CALL int aocl_mmd_program( int handle, void * user_data, size_t size, a
 #define AOCL_MMD_ERROR_INVALID_POINTER        -5
 #define AOCL_MMD_ERROR_INVALID_MIGRATION_SIZE -6
 
-/** Memory properties*/
+/**
+ *  Memory properties
+ */
 typedef enum {
   /**
    *  Specifies the name of a global memory that can be found in the
@@ -479,10 +258,10 @@ typedef enum {
    */
   AOCL_MMD_MEM_PROPERTIES_GLOBAL_MEMORY=1,
   /**
-   *  Specifies the index of a bank inside the global memory interface that can be found in
-   *  the board_spec.xml file for the BSP. Allocations will be allocated to this
-   *  memory bank. It is invalid to specify this property without also specifying
-   *  AOCL_MMD_GLOBAL_MEMORY_INTERFACE.
+   *  Specifies the index of a bank inside the global memory interface that can be
+   *  found in the board_spec.xml file for the BSP. Allocations will be allocated
+   *  to this memory bank. It is invalid to specify this property without also
+   *  specifying AOCL_MMD_GLOBAL_MEMORY_INTERFACE.
    */
   AOCL_MMD_MEM_PROPERTIES_MEMORY_BANK,
   /**
@@ -496,7 +275,331 @@ typedef enum {
   AOCL_MMD_MEM_PROPERTIES_BUFFER_LOCATION
 } aocl_mmd_mem_properties_t;
 
+
 /**
+ *  Shared allocation migration destinations
+ */
+typedef enum {
+  AOCL_MMD_MIGRATE_TO_HOST = 0,
+  AOCL_MMD_MIGRATE_TO_DEVICE = 1
+} aocl_mmd_migrate_t;
+
+
+/**
+ *  REQUIRED FUNCTION
+ *
+ *  Get information about the board using the enum aocl_mmd_offline_info_t for
+ *  offline info (called without a handle), and the enum aocl_mmd_info_t for
+ *  info specific to a certain board.
+ *
+ *  @param  requested_info_id: A value from the aocl_mmd_offline_info_t enum
+ *  @param  param_value_size: Size of the param_value field in bytes. This should
+ *          match the size of the return type expected as indicated in the enum
+ *          definition. For example, the AOCL_MMD_TEMPERATURE returns a float, so
+ *          the param_value_size should be set to sizeof(float) and you should
+ *          expect the same number of bytes returned in param_size_ret.
+ *  @param  param_value: Pointer to the variable that will receive the returned info
+ *  @param  param_size_ret: Receives the number of bytes of data actually returned
+ *  @return A negative value to indicate error.
+ */
+AOCL_MMD_CALL int aocl_mmd_get_offline_info(
+    aocl_mmd_offline_info_t requested_info_id,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_size_ret) WEAK;
+AOCL_MMD_CALL int aocl_mmd_get_info(
+    int handle,
+    aocl_mmd_info_t requested_info_id,
+    size_t param_value_size,
+    void* param_value,
+    size_t* param_size_ret) WEAK;
+
+/**
+ *  REQUIRED FUNCTION
+ *
+ *  Open and initialize the named device.
+ *
+ *  The name is typically one specified by the AOCL_MMD_BOARD_NAMES offline
+ *  info.
+ *
+ *  @param  name: Open the board with this name (provided as a C-style string,
+ *          i.e. NUL terminated ASCII.)
+ *  @return the non-negative integer handle for the board, otherwise a negative
+ *          value to indicate error. Upon receiving the error, the OpenCL runtime
+ *          will proceed to open other known devices, hence the MMD mustn't
+ *          exit the application if an open call fails.
+ */
+AOCL_MMD_CALL int aocl_mmd_open(const char *name) WEAK;
+
+/**
+ *  REQUIRED FUNCTION
+ *
+ *  Close an opened device, by its handle.
+ *
+ *  @return 0 on success, negative values on error.
+ */
+AOCL_MMD_CALL int aocl_mmd_close(int handle) WEAK;
+
+/**
+ *  REQUIRED FUNCTION
+ *
+ *  Set the interrupt handler for the opened device.
+ *  The interrupt handler is called whenever the client needs to be notified
+ *  of an asynchronous event signaled by the device internals.
+ *  For example, the kernel has completed or is stalled.
+ *
+ *  Important: Interrupts from the kernel must be ignored until this handler is
+ *  set
+ *
+ *  @param  fn: The callback function to invoke when a kernel interrupt occurs
+ *  @param  user_data: The data that should be passed to fn when it is called.
+ *
+ *  @return 0 if successful, negative on error
+ */
+AOCL_MMD_CALL int aocl_mmd_set_interrupt_handler(
+      int handle,
+      aocl_mmd_interrupt_handler_fn fn,
+      void* user_data) WEAK;
+
+/**
+ *  OPTIONAL FUNCTION
+ *
+ *  Set the device interrupt handler for the opened device.
+ *  The device interrupt handler is called whenever the client needs to be notified
+ *  of a device event signaled by the device internals.
+ *  For example, an ECC error has been reported.
+ *
+ *  Important: Interrupts from the device must be ignored until this handler is
+ *  set
+ *
+ *  @param  fn: The callback function to invoke when a device interrupt occurs
+ *  @param  user_data: The data that should be passed to fn when it is called.
+ *  @return 0 if successful, negative on error
+ */
+AOCL_MMD_CALL int aocl_mmd_set_device_interrupt_handler(
+      int handle,
+      aocl_mmd_device_interrupt_handler_fn fn,
+      void* user_data) WEAK;
+
+/**
+ *  REQUIRED FUNCTION
+ *
+ *  Set the operation status handler for the opened device.
+ *  The operation status handler is called with
+ *     status 0 when the operation has completed successfully.
+ *     status negative when the operation completed with errors.
+ *
+ *   @param  fn: The callback function to invoke when a status update is to be
+ *           performed.
+ *   @param  user_data: The data that should be passed to fn when it is called.
+ *   @return 0 if successful, negative on error
+ */
+AOCL_MMD_CALL int aocl_mmd_set_status_handler(
+      int handle,
+      aocl_mmd_status_handler_fn fn,
+      void* user_data) WEAK;
+
+/**
+ *  REQUIRED FUNCTION
+ *
+ *  If AOCL_MMD_USES_YIELD is 1, this function is called when the host is idle
+ *  and hence possibly waiting for events to be processed by the device.
+ *  If AOCL_MMD_USES_YIELD is 0, this function is never called and the MMD is
+ *  assumed to provide status/event updates via some other execution thread
+ *  such as through an interrupt handler.
+ *
+ *  @return non-zero if the yield function performed useful work such as
+ *          processing DMA transactions, 0 if there is no useful work to be performed
+ *
+ *  NOTE: yield may be called continuously as long as it reports that it has useful work
+ */
+AOCL_MMD_CALL int aocl_mmd_yield(int handle) WEAK;
+
+/**
+ *  REQUIRED FUNCTION
+ *
+ *  Read, write and copy operations on a single interface.
+ *  If op is NULL
+ *     - Then these calls must block until the operation is complete.
+ *     - The status handler is not called for this operation.
+ *
+ *  If op is non-NULL, then:
+ *     - These may be non-blocking calls
+ *     - The status handler must be called upon completion, with status 0
+ *       for success, and a negative value for failure.
+ *
+ *  @param  op: The operation object used to track this operations progress
+ *  @param  len: The size in bytes to transfer
+ *  @param  src: The host buffer being read from
+ *  @param  dst: The host buffer being written to
+ *  @param  mmd_interface: The handle to the interface being accessed. E.g. To
+ *          access global memory this handle will be whatever is returned by
+ *          aocl_mmd_get_info when called with AOCL_MMD_MEMORY_INTERFACE.
+ *  @param  offset/src_offset/dst_offset: The byte offset within the interface that
+ *          the transfer will begin at.
+ *  @return 0 if the operation launch was successful, and negative otherwise.
+ */
+AOCL_MMD_CALL int aocl_mmd_read(
+      int handle,
+      aocl_mmd_op_t op,
+      size_t len,
+      void* dst,
+      int mmd_interface,
+      size_t offset) WEAK;
+AOCL_MMD_CALL int aocl_mmd_write(
+      int handle,
+      aocl_mmd_op_t op,
+      size_t len,
+      const void* src,
+      int mmd_interface,
+      size_t offset) WEAK;
+AOCL_MMD_CALL int aocl_mmd_copy(
+      int handle,
+      aocl_mmd_op_t op,
+      size_t len,
+      int mmd_interface,
+      size_t src_offset,
+      size_t dst_offset) WEAK;
+
+/**
+ *  OPTIONAL FUNCTION
+ *
+ *  Host Channel create operation
+ *  Opens channel between host and kernel.
+ *
+ *  @param  channel_name: Name of channel to initialize. Same name as used in
+            board_spec.xml
+ *  @param  queue_depth: The size in bytes of pinned memory queue in system memory
+ *  @param  direction: The direction of the channel
+ *  @return negative if initialization was unsuccessful, and positive otherwise.
+            Positive return value is handle to the channel to be used for
+            subsequent calls for the channel.
+ */
+AOCL_MMD_CALL int aocl_mmd_hostchannel_create(
+      int handle,
+      char *channel_name,
+      size_t queue_depth,
+      int direction) WEAK;
+
+/**
+ *  OPTIONAL FUNCTION
+ *
+ *  Host Channel destroy operation
+ *  Closes channel between host and kernel.
+ *
+ *  @param  channel: The handle to the channel to close, that was obtained with
+ *          create channel
+ *  @return 0 if the destroy was successful, and negative otherwise.
+ */
+AOCL_MMD_CALL int aocl_mmd_hostchannel_destroy(
+      int handle,
+      int channel) WEAK;
+
+/**
+ *  OPTIONAL FUNCTION
+ *
+ *  Host Channel get buffer operation
+ *
+ *  Provide host with pointer to data buffer they can access to write or
+ *  read from kernel, along with space or data available in the buffer
+ *  in bytes.
+ *
+ *  @param  channel: The handle to the channel to get the data buffer for
+ *  @param  buffer_size: The address that this call will write the amount of
+ *          space or data that's available in the buffer,
+ *          depending on direction of the channel, in bytes
+ *  @param  status: The address that this call will write to for result of this
+ *          call. Value will be 0 for success, and negative otherwise
+ *  @return The pointer to the data buffer that host can write to or read from.
+ *          NULL if the status is negative.
+ */
+AOCL_MMD_CALL void *aocl_mmd_hostchannel_get_buffer(
+      int handle,
+      int channel,
+      size_t *buffer_size,
+      int *status ) WEAK;
+
+/**
+ *  OPTIONAL FUNCTION
+ *
+ *  Host Channel get sideband signal buffer operation
+ *  Provide host with pointer to sideband signal buffer associated with
+ *  data buffer as obtained from the get buffer operation, corresponding
+ *  to the given port ID, along with space or data available in the buffer
+ *  in bytes.
+ *
+ *  @param  channel: The handle to the channel to get the sideband signal buffer
+ *          for
+ *  @param  port_id: The ID to identify which sideband signal buffer to return
+ *  @param  buffer_size: The address that this call will write the amount of
+ *          space or data that's available in the buffer,
+ *          depending on direction of the channel, in bytes
+ *  @param  status: The address that this call will write to for result of this
+ *          call. Value will be 0 for success, and negative otherwise
+ *  @return The pointer to the sideband buffer that host can write to or read
+ *          from. NULL if the status is negative.
+ */
+AOCL_MMD_CALL void *aocl_mmd_hostchannel_get_sideband_buffer(
+      int handle,
+      int channel,
+      aocl_mmd_hostchannel_port_id_t port_id,
+      size_t *buffer_size,
+      int *status);
+
+/**
+ *  OPTIONAL FUNCTION
+ *
+ *  Host Channel acknowledge buffer operation
+ *  Acknowledge to the channel that the user has written or read data from
+ *  it. This will make the data or additional buffer space available to
+ *  write to or read from kernel.
+ *
+ *  @param  channel: The handle to the channel that user is acknowledging
+ *  @param  send_size: The size in bytes that the user is acknowledging
+ *  @param  status: The address that this call will write to for result of this
+ *          call. Value will be 0 for success, and negative otherwise
+ *  @return The return value is equal to send_size if send_size was less than or
+ *          equal to the buffer_size from get buffer call. If send_size was
+ *          greater, then return value is the amount that was actually sent.
+ */
+AOCL_MMD_CALL size_t aocl_mmd_hostchannel_ack_buffer(
+      int handle,
+      int channel,
+      size_t send_size,
+      int *status) WEAK;
+
+/**
+ *  OPTIONAL FUNCTION
+ *
+ *  Program the device
+ *
+ *  The host will guarantee that no operations are currently executing on the
+ *  device. That means the kernels will be idle and no read/write/copy
+ *  commands are active. Interrupts should be disabled and the FPGA should
+ *  be reprogrammed with the data from user_data which has size size. The host
+ *  will then call aocl_mmd_set_status_handler and aocl_mmd_set_interrupt_handler
+ *  again. At this point interrupts can be enabled.
+ *
+ *  The new handle to the board after reprogram does not have to be the same as
+ *  the one before.
+ *
+ *  @param  user_data: The binary contents of the fpga.bin file created during
+ *          Quartus II compilation.
+ *  @param  size: The size in bytes of user_data
+ *  @param  program_mode: Bit field for programming attributes. See
+ *          aocl_mmd_program_mode_t definition
+ *  @return The new non-negative integer handle for the board, otherwise a
+ *          negative value to indicate error.
+ */
+AOCL_MMD_CALL int aocl_mmd_program(
+      int handle,
+      void * user_data,
+      size_t size,
+      aocl_mmd_program_mode_t program_mode) WEAK;
+
+/**
+ *  OPTIONAL FUNCTION
+ *
  *  Host allocations provide memory that is allocated on the host. Host
  *  allocations are accessible by the host and one or more devices.
  *  The same pointer to a host allocation may be used on the host and all
@@ -507,49 +610,66 @@ typedef enum {
  *  aocl_mmd_interrupt_handler_fn() the host can assume it has access to the
  *  latest contents of the memory, allocated by this call.
  *
- *  @param handles Handles for devices that will need access to this memory
- *  @param num_devices Number of devices in the handles
- *  @param size The size of the memory region
- *  @param alignment The alignment in bytes of the allocation
- *  @param properties Specifies additional information about the allocated
- *    memory, described by a property type name and its corresponding value.
- *    Each property type name is immediately followed by the corresponding
- *    desired value. The list is terminated with 0. Supported values are
- *    described above. Example: [<property1>, <value1>, <property2>, <value2>, 0]
- *  @param error The error code defined by AOCL_MMD_ERROR*
- *  @return valid pointer, on error NULL
+ *  @param  handles: Handles for devices that will need access to this memory
+ *  @param  num_devices: Number of devices in the handles
+ *  @param  size: The size of the memory region
+ *  @param  alignment: The alignment in bytes of the allocation
+ *  @param  properties: Specifies additional information about the allocated
+ *          memory, described by a property type name and its corresponding value.
+ *          Each property type name is immediately followed by the corresponding
+ *          desired value. The list is terminated with 0. Supported values are
+ *          described above. Example: [<property1>, <value1>, <property2>, <value2>, 0]
+ *  @param  error: The error code defined by AOCL_MMD_ERROR*
+ *  @return to or read from.alid pointer, on error NULL
  */
-AOCL_MMD_CALL void* aocl_mmd_host_alloc (int* handles, size_t num_devices, size_t size, size_t alignment, aocl_mmd_mem_properties_t *properties, int* error) WEAK;
+AOCL_MMD_CALL void* aocl_mmd_host_alloc(
+      int* handles,
+      size_t num_devices,
+      size_t size,
+      size_t alignment,
+      aocl_mmd_mem_properties_t *properties,
+      int* error) WEAK;
 
 /**
- * Frees memory that has been allocated by MMD
+ *  OPTIONAL FUNCTION
  *
- * @param mem The pointer to the memory region. Must be a pointer that is
- *   allocated by the MMD.
- * @return AOCL_MMD_ERROR_SUCCESS if success, else error code
+ *  Frees memory that has been allocated by MMD
+ *
+ *  @param  mem: The pointer to the memory region. Must be a pointer that is
+ *          allocated by the MMD.
+ *  @return AOCL_MMD_ERROR_SUCCESS if success, else error code
  */
-AOCL_MMD_CALL int aocl_mmd_free (void* mem) WEAK;
+AOCL_MMD_CALL int aocl_mmd_free(void* mem) WEAK;
 
 /**
+ *  OPTIONAL FUNCTION
+ *
  *  Allocate memory that is owned by the device. This pointer can only be
  *  accessed by the kernel; can't be accessed by the host. The host is able to
  *  manipulate the pointer (e.g. increment it) just not access the underlying
  *  data. This memory must be deallocated by aocl_mmd_free();
  *
- *  @param  handle Device that will have access to this memory
- *  @param  size The size of the memory region
- *  @param  alignment The alignment in bytes of the memory region
- *  @param  properties Specifies additional information about the allocated
- *    memory, described by a property type name and its corresponding value.
- *    Each property type name is immediately followed by the corresponding
- *    desired value. The list is terminated with 0. Supported values are
- *    described above. Example: [<property1>, <value1>, <property2>, <value2>, 0]
- *  @param error The error code defined by AOCL_MMD_ERROR*
+ *  @param  handle: Device that will have access to this memory
+ *  @param  size: The size of the memory region
+ *  @param  alignment: The alignment in bytes of the memory region
+ *  @param  properties: Specifies additional information about the allocated
+ *          memory, described by a property type name and its corresponding value.
+ *          Each property type name is immediately followed by the corresponding
+ *          desired value. The list is terminated with 0. Supported values are
+ *          described above. Example: [<property1>, <value1>, <property2>, <value2>, 0]
+ *  @param  error: The error code defined by AOCL_MMD_ERROR*
  *  @return Pointer that can be passed into the kernel. NULL on failure.
  */
-AOCL_MMD_CALL void * aocl_mmd_device_alloc( int handle, size_t size, size_t alignment, aocl_mmd_mem_properties_t *properties, int* error) WEAK;
+AOCL_MMD_CALL void * aocl_mmd_device_alloc(
+      int handle,
+      size_t size,
+      size_t alignment,
+      aocl_mmd_mem_properties_t *properties,
+      int* error) WEAK;
 
 /**
+ *  OPTIONAL FUNCTION
+ *
  *  Shared allocations may migrate between the host and one or more associated
  *  device. The same pointer to a shared allocation may be used on the host and
  *  the supported device; they have address equivalence.
@@ -572,26 +692,28 @@ AOCL_MMD_CALL void * aocl_mmd_device_alloc( int handle, size_t size, size_t alig
  *  Memory allocated by aocl_mmd_shared_alloc() must be deallocated with
  *  aocl_mmd_free().
  *
- *  @param  handle Device that will have access to this memory
- *  @param  size The size of the memory region
- *  @param alignment The alignment in bytes of the memory region
- *  @param  properties Specifies additional information about the allocated
- *    memory, described by a property type name and its corresponding value.
- *    Each property type name is immediately followed by the corresponding
- *    desired value. The list is terminated with 0. Supported properties are
- *    listed above and have the prefix AOCL_MMD_MEM_PROPERTIES_.
- *    Example: [<property1>, <value1>, <property2>, <value2>, 0]
- *  @param error The error code defined by AOCL_MMD_ERROR*
- *  @return valid pointer, on error NULL
+ *  @param  handle: Device that will have access to this memory
+ *  @param  size: The size of the memory region
+ *  @param  alignment: The alignment in bytes of the memory region
+ *  @param  properties: Specifies additional information about the allocated
+ *          memory, described by a property type name and its corresponding value.
+ *          Each property type name is immediately followed by the corresponding
+ *          desired value. The list is terminated with 0. Supported properties are
+ *          listed above and have the prefix AOCL_MMD_MEM_PROPERTIES_.
+ *          Example: [<property1>, <value1>, <property2>, <value2>, 0]
+ *  @param  error: The error code defined by AOCL_MMD_ERROR*
+ *  @return Valid pointer, on error NULL
  */
-AOCL_MMD_CALL void * aocl_mmd_shared_alloc( int handle, size_t size, size_t alignment, aocl_mmd_mem_properties_t* properties, int* error) WEAK;
-
-typedef enum {
-  AOCL_MMD_MIGRATE_TO_HOST = 0,
-  AOCL_MMD_MIGRATE_TO_DEVICE = 1
-} aocl_mmd_migrate_t;
+AOCL_MMD_CALL void * aocl_mmd_shared_alloc(
+      int handle,
+      size_t size,
+      size_t alignment,
+      aocl_mmd_mem_properties_t* properties,
+      int* error) WEAK;
 
 /**
+ *  OPTIONAL FUNCTION
+ *
  *  A call to aocl_mmd_shared_migrate() must be made for non-concurrent shared
  *  allocations any time the accessor of the allocation changes.  For example,
  *  aocl_mmd_shared_migrate() should be called indicating that the allocation
@@ -603,14 +725,18 @@ typedef enum {
  *  For concurrent allocations this call may be used as a performance hint, but
  *  is not strictly required for functionality.
  *
- *  @param  handle Device that will have access to this memory
- *  @param shared_ptr Pointer allocated by aocl_mmd_shared_alloc()
- *  @param size In bytes, the size of the migration. Must be of multiple of a
- *   page boundary that the BSP supports.
- *  @param destination The destination of migration
+ *  @param  handle: Device that will have access to this memory
+ *  @param  shared_ptr: Pointer allocated by aocl_mmd_shared_alloc()
+ *  @param  size: In bytes, the size of the migration. Must be of multiple of a
+ *          page boundary that the BSP supports.
+ *  @param  destination: The destination of migration
  *  @return The error code defined by AOCL_MMD_ERROR*
  */
-AOCL_MMD_CALL int aocl_mmd_shared_migrate(int handle, void* shared_ptr, size_t size, aocl_mmd_migrate_t destination) WEAK;
+AOCL_MMD_CALL int aocl_mmd_shared_migrate(
+      int handle,
+      void* shared_ptr,
+      size_t size,
+      aocl_mmd_migrate_t destination) WEAK;
 
 #ifdef __cplusplus
 }

--- a/include/acl.h
+++ b/include/acl.h
@@ -468,6 +468,7 @@ typedef struct {
   cl_mem_alloc_flags_intel alloc_flags;
   cl_unified_shared_memory_type_intel type;
   cl_uint alignment; // May not be needed. Track for now.
+  cl_uint host_shared_mem_id;
 } acl_usm_allocation_t;
 
 typedef struct {
@@ -556,16 +557,6 @@ struct acl_sideband_signal_mapping {
   unsigned port_identifier;
   unsigned port_offset;   // bit
   unsigned sideband_size; // bit
-};
-
-// Must match the definition in the compiler
-// Analysis/FPGAAnalysis/Utils/StreamParameters.h
-enum signal_type {
-  SignalUnknown = -1,
-  AvalonData = 0,
-  AvalonSop = 1,
-  AvalonEop = 2,
-  AvalonEmpty = 3
 };
 
 // Part of acl_device_def_t where members are populated from the information

--- a/include/acl_hal.h
+++ b/include/acl_hal.h
@@ -184,6 +184,8 @@ typedef struct {
   int (*has_svm_memory_support)(unsigned int physical_device_id, int *value);
   /// Returns 1 if physical mem is supported
   int (*has_physical_mem)(unsigned int physical_device_id);
+  /// Returns 1 if buffer location is supported across devices
+  int (*support_buffer_location)(const std::vector<cl_device_id> &devices);
 
   /// Get pointer to board specific extension functions
   void *(*get_board_extension_function_address)(
@@ -266,14 +268,7 @@ typedef struct {
       unsigned int physical_device_id, const char *interface_name,
       const void *host_addr, size_t dev_addr, size_t size);
 
-  /// Simulation only mmd call as of 2024.1
-  /// Return the sideband signal buffer corresponding to the side band signal
-  /// port identifier
-  void *(*hostchannel_get_sideband_buffer)(unsigned int physical_device_id,
-                                           unsigned int port_name,
-                                           int channel_handle,
-                                           size_t *buffer_size, int *status);
-
+  /// Simulation only hal function as of 2024.1
   /// Pull read_size of sideband data from the device into host_buffer, WITHOUT
   /// acknowledge
   size_t (*hostchannel_sideband_pull_no_ack)(unsigned int physical_device_id,
@@ -282,6 +277,7 @@ typedef struct {
                                              void *host_buffer,
                                              size_t read_size, int *status);
 
+  /// Simulation only hal function as of 2024.1
   /// Push write_size of sideband data to the device from host_buffer, WITHOUT
   /// acknowledge
   size_t (*hostchannel_sideband_push_no_ack)(unsigned int physical_device_id,

--- a/include/acl_hal_mmd.h
+++ b/include/acl_hal_mmd.h
@@ -283,10 +283,9 @@ typedef struct {
   // port identifier Get a pointer to the mmd buffer for the host channel
   // Simulation only mmd call as of 2024.1. HW MMD developer needs to implement
   // this function in the future To support hostpipe sideband signals.
-  void *(*aocl_mmd_hostchannel_get_sideband_buffer)(int handle, int channel,
-                                                    int port_id,
-                                                    size_t *buffer_size,
-                                                    int *status);
+  void *(*aocl_mmd_hostchannel_get_sideband_buffer)(
+      int handle, int channel, aocl_mmd_hostchannel_port_id_t port_id,
+      size_t *buffer_size, int *status);
 
 } acl_mmd_dispatch_t;
 

--- a/include/acl_types.h
+++ b/include/acl_types.h
@@ -296,7 +296,8 @@ typedef struct host_op_struct {
 } host_op_t;
 
 struct sideband_signal_t {
-  unsigned port_identifier; // matches enum signal_type in acl.h
+  unsigned port_identifier; // matches enum aocl_mmd_hostchannel_port_id_t in
+                            // aocl_mmd.h
   unsigned port_offset;     // in bit
   unsigned side_band_size;  // in bit
 };

--- a/src/acl_hostch.cpp
+++ b/src/acl_hostch.cpp
@@ -71,7 +71,8 @@ static cl_int l_push_sideband_packet(unsigned int physical_device_id,
   for (auto const &sideband_signal_entry :
        host_pipe_info.side_band_signals_vector) {
     size_t pushed_data;
-    if (sideband_signal_entry.port_identifier == AvalonData) {
+    if (sideband_signal_entry.port_identifier ==
+        static_cast<unsigned>(AOCL_MMD_HOSTCHANNEL_PORT_DATA)) {
       pushed_data = acl_get_hal()->hostchannel_push_no_ack(
           host_pipe_info.m_physical_device_id, host_pipe_info.m_channel_handle,
           (const void *)((char *)host_buffer +
@@ -117,7 +118,8 @@ static size_t l_pull_sideband_packet(unsigned int physical_device_id,
   for (auto const &sideband_signal_entry :
        host_pipe_info.side_band_signals_vector) {
     size_t pulled_data;
-    if (sideband_signal_entry.port_identifier == AvalonData) {
+    if (sideband_signal_entry.port_identifier ==
+        static_cast<unsigned>(AOCL_MMD_HOSTCHANNEL_PORT_DATA)) {
       pulled_data = acl_get_hal()->hostchannel_pull_no_ack(
           host_pipe_info.m_physical_device_id, host_pipe_info.m_channel_handle,
           (void *)((char *)host_buffer + sideband_signal_entry.port_offset / 8),

--- a/src/acl_offline_hal.cpp
+++ b/src/acl_offline_hal.cpp
@@ -143,6 +143,7 @@ static const acl_hal_t acl_offline_hal = {
     acl_offline_hal_set_profile_stop_cycle,
     acl_offline_hal_has_svm_memory_support,
     acl_offline_hal_has_physical_mem,
+    NULL,
     acl_offline_hal_get_board_extension_function_address,
     acl_offline_hal_pll_reconfigure,
     acl_offline_hal_reset_kernels,

--- a/src/acl_program.cpp
+++ b/src/acl_program.cpp
@@ -1396,7 +1396,8 @@ l_register_hostpipes_to_program(acl_device_program_info_t *dev_prog,
 
     auto &host_pipe_info =
         dev_prog->program_hostpipe_map.at(sideband_signal_mapping.logical_name);
-    if (sideband_signal_mapping.port_identifier != AvalonData) {
+    if (sideband_signal_mapping.port_identifier !=
+        static_cast<unsigned>(AOCL_MMD_HOSTCHANNEL_PORT_DATA)) {
       host_pipe_info.num_side_band_signals++;
     }
 

--- a/test/acl_hal_test.cpp
+++ b/test/acl_hal_test.cpp
@@ -30,6 +30,7 @@ static int acl_test_svm_memory_support =
     (CL_DEVICE_SVM_COARSE_GRAIN_BUFFER | CL_DEVICE_SVM_FINE_GRAIN_BUFFER |
      CL_DEVICE_SVM_FINE_GRAIN_SYSTEM);
 static bool acl_test_physical_memory_support = true;
+static bool acl_test_buffer_location_support = true;
 
 // Parts of a valid HAL.
 void acltest_hal_init_device(const acl_system_def_t *def);
@@ -81,6 +82,8 @@ int acltest_hal_set_profile_stop_cycle(unsigned int physical_device_id,
                                        unsigned int accel_id, uint64_t value);
 int acl_test_hal_has_svm_support(unsigned int physical_device_id, int *value);
 int acl_test_hal_has_physical_mem(unsigned int physical_device_id);
+int acl_test_hal_support_buffer_location(
+    const std::vector<cl_device_id> &devices);
 int acl_test_hal_pll_reconfigure(unsigned int physical_device_id,
                                  const char *pll_settings_str);
 void acl_test_hal_reset_kernels(cl_device_id device);
@@ -128,6 +131,7 @@ static const acl_hal_t simple_hal = {acltest_hal_init_device,
                                      acltest_hal_set_profile_stop_cycle,
                                      acl_test_hal_has_svm_support,
                                      acl_test_hal_has_physical_mem,
+                                     acl_test_hal_support_buffer_location,
                                      0,
                                      acl_test_hal_pll_reconfigure,
                                      acl_test_hal_reset_kernels,
@@ -589,6 +593,10 @@ void acl_test_hal_set_physical_memory_support(bool value) {
   acl_test_physical_memory_support = value;
 }
 
+void acl_test_hal_set_buffer_location_support(bool value) {
+  acl_test_buffer_location_support = value;
+}
+
 int acl_test_hal_has_svm_support(unsigned int physical_device_id, int *value) {
   physical_device_id = physical_device_id; // Avoid Windows warning
   *value = acl_test_svm_memory_support;
@@ -598,6 +606,11 @@ int acl_test_hal_has_svm_support(unsigned int physical_device_id, int *value) {
 int acl_test_hal_has_physical_mem(unsigned int physical_device_id) {
   physical_device_id = physical_device_id; // Avoid Windows warning
   return acl_test_physical_memory_support;
+}
+
+int acl_test_hal_support_buffer_location(
+    const std::vector<cl_device_id> &devices) {
+  return acl_test_buffer_location_support;
 }
 
 int acl_test_hal_pll_reconfigure(unsigned int physical_device_id,

--- a/test/acl_hal_test.h
+++ b/test/acl_hal_test.h
@@ -16,6 +16,7 @@ void *acltest_translate_device_address(const void *device_ptr, size_t offset);
 
 void acl_test_hal_set_svm_memory_support(int value);
 void acl_test_hal_set_physical_memory_support(bool value);
+void acl_test_hal_set_buffer_location_support(bool value);
 
 extern bool acltest_hal_emulate_device_mem;
 


### PR DESCRIPTION
This change also:
- Determines MMD buffer location support based on MMD verison
- Formally define host pipe side band port id in aocl_mmd.h
- Support querying buffer location on host/shared USM allocation

(cherry picked from commit dc2a3225b279ad9e00a71b557229908dde7a5c96)