### PR TITLE
Return the global memory with enough capacity as default mem_id

### DIFF
--- a/include/acl_mem.h
+++ b/include/acl_mem.h
@@ -69,6 +69,8 @@ cl_int acl_reserve_buffer_block(cl_mem mem, acl_mem_region_t *region,
 
 int acl_get_default_memory(const acl_device_def_t &dev);
 int acl_get_default_device_global_memory(const acl_device_def_t &dev);
+int acl_get_fit_device_global_memory(const acl_device_def_t &dev,
+                                     const size_t size);
 
 void acl_mem_destructor_callback(
     cl_mem memobj); // The function that calls the user registered callbacks via

--- a/include/acl_types.h
+++ b/include/acl_types.h
@@ -947,6 +947,7 @@ typedef struct _cl_mem {
 
   // If this is a heterogeneous buffer, what is the index of the memory it uses
   unsigned int mem_id;
+  bool buffer_location_set;
 
   // Is this buffer an SVM buffer
   int is_svm;


### PR DESCRIPTION
For heterogeneous memory system where each global memory has the same size, the memory with address range starting at 0x0 may have a smaller usable range than the other memories as we need to avoid allocating at 0x0. As a result, if user allocates a buffer with size of CL_DEVICE_MAX_MEM_ALLOC_SIZE, it will need to be allocated to one of the other memories. This change updates the way default `gmem_id` is found, by taking the allocation size into account.