### PR TITLE
Added glibc_wrap to provide Linux OS backwards compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ set(CPACK_PACKAGE_VERSION_PATCH "0")
 set(CPACK_PACKAGE_DESCRIPTION_FILE "${CMAKE_CURRENT_SOURCE_DIR}/README.md")
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 
+if (NOT WIN32)
+    set(GLIBC_WRAP_FUNCTIONS
+        -Wl,--wrap=gettid
+        -Wl,--wrap=log2)
+endif()
 # Enforce keeping the source directory clean by building in a separate
 # directory. This avoids unnecessary corner cases, e.g., copying files
 # from source to binary directory with identical relative paths.
@@ -333,7 +338,10 @@ target_link_libraries(acl PRIVATE
 if(UNIX)
   # we need this flag to expose symbols, otherwise linking will fail with:
   # "relocation against protected symbol X can not be used when making a shared object"
+  add_subdirectory(glibc_wrap)
   set_target_properties(acl PROPERTIES LINK_FLAGS "-Wl,-Bsymbolic")
+  target_include_directories(acl PRIVATE ${CMAKE_SOURCE_DIR}/glibc_wrap)
+  target_link_libraries(acl PRIVATE glibc_wrap)
 endif()
 
 set_property(TARGET acl PROPERTY PUBLIC_HEADER

--- a/cmake/manifests/linux/install_manifest.txt
+++ b/cmake/manifests/linux/install_manifest.txt
@@ -37,3 +37,4 @@
 /fpga-runtime-for-opencl/include/CL/opencl.hpp
 /fpga-runtime-for-opencl/include/MMD/aocl_mmd.h
 /fpga-runtime-for-opencl/include/MMD/aocl_mmd_deprecated.h
+/__w/fpga-runtime-for-opencl/fpga-runtime-for-opencl/glibc_wrap/libglibc_wrap.a

--- a/glibc_wrap/CMakeLists.txt
+++ b/glibc_wrap/CMakeLists.txt
@@ -1,0 +1,16 @@
+if (NOT WIN32)
+    add_library(glibc_wrap STATIC glibc_wrap.c)
+    # Ensure position-independent code is generated
+    set_target_properties(glibc_wrap PROPERTIES POSITION_INDEPENDENT_CODE ON)
+    target_include_directories(glibc_wrap PRIVATE ${CMAKE_SOURCE_DIR}/src)
+    # Specify the wrapped functions on the interface link options.
+    # This causes libraries linking against this one to use the wrapped 
+    # functions rather than those in a potentially too new glibc for
+    # our minimum supported OS. See glibc_wrap.c for details.
+    target_link_libraries(glibc_wrap INTERFACE ${GLIBC_WRAP_FUNCTIONS})
+    
+    # Link the math library for debian-11-arm-dev
+    target_link_libraries(glibc_wrap INTERFACE m)
+
+    install(TARGETS glibc_wrap DESTINATION ${CMAKE_SOURCE_DIR}/glibc_wrap)
+endif()

--- a/glibc_wrap/glibc_wrap.c
+++ b/glibc_wrap/glibc_wrap.c
@@ -1,0 +1,30 @@
+// These functions are only called by our code when built on newer distros. We
+// add '-Wl,--wrap={funcname}' to the link line which changes all calls to
+// '{funcname}' to '__wrap_{funcname}'
+
+// For all the gritty details:
+// https://www.win.tue.nl/~aeb/linux/misc/gcc-semibug.html
+// https://stackoverflow.com/questions/4032373/linking-against-an-old-version-of-libc-to-provide-greater-application-coverage
+
+#include <linux/unistd.h>
+#include <math.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+#ifndef __arm__
+// Use GLIBC 2.2.5 versioning only if not on ARM
+asm(".symver log2_glibc_225, log2@GLIBC_2.2.5");
+extern double log2_glibc_225(double num);
+#endif
+
+double __wrap_log2(double num) {
+#ifdef __arm__
+  // If compiling for ARM, just call the system-native log2 function
+  return log2(num);
+#else
+  // Call the GLIBC 2.2.5 version of log2 if not on ARM
+  return log2_glibc_225(num);
+#endif
+}
+
+pid_t __wrap_gettid(void) { return (pid_t)syscall(SYS_gettid); }


### PR DESCRIPTION
Our CI/CD is moving to SUSE15, but we need to support a GLIBC version (2.28) that is below the native GLIBC version on SUSE15) 
This change implements a wrapping mechanism that will explicitly link against the older GLIBC functions or syscall functions to the extent required for our oldest supported GLIBC (2.28)

The implementation is based on that used in hld-backend and DSPBA https://github.com/intel-innersource/applications.fpga.oneapi.products.hld-backend-source/pull/510

### Tests run:
I've verified with nm that without linking the wrapper, the `libalteracl.so` file uses GLIBC 2.29 for `log` operation and GLIBC 2.30 for `gettid`. With the wrapper it uses glibc2.2.5 for log operation and syscall for `gettid`.

Local build also passes with this change: https://psg-sc-arc.sc.intel.com/arc/dashboard/reports/show_job/941516093