### PR TITLE
Use mutex to ensure segment update and CRA read/write happens atomically

### DIFF
--- a/include/acl_kernel_if.h
+++ b/include/acl_kernel_if.h
@@ -12,6 +12,7 @@
 #include "acl_hal.h"
 #include "acl_types.h"
 
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -59,6 +60,12 @@ typedef struct {
   uintptr_t cur_segment;
 
   acl_bsp_io io;
+
+  // Acquired when any thread is trying to perform CRA non-ROM read or write.
+  // This is to ensure that CRA segment register write happens concurrently
+  // with the subsequent data read or write, so the data read or write goes
+  // to the CRA of the intended kernel.
+  std::mutex segment_mutex;
 
   // csr_version is absent if there is no accelerators or cra_ring_root doesn't
   // exist

--- a/include/acl_kernel_if.h
+++ b/include/acl_kernel_if.h
@@ -32,10 +32,19 @@ typedef struct {
 
   // Accelerator details
   unsigned int num_accel;
-  std::vector<std::vector<int>>
-      accel_job_ids; //[num_accel][accel_invoc_queue_depth]
+
+  // Circular buffer that implements hardware kernel invocation queue
+  // size: [num_accel][accel_invoc_queue_depth]
+  std::vector<std::vector<int>> accel_job_ids;
+  // Depth of hardware kernel invocation queue [num_accel]
+  std::vector<unsigned int> accel_invoc_queue_depth;
+  // Points to the last kernel that has been launched but not yet finished
+  // [num_accel]
   std::vector<int> accel_queue_front;
+  // Points to the last empty slot on hardware kernel invocation queue
+  // where kernel at the next index is the next one to finish [num_accel]
   std::vector<int> accel_queue_back;
+
   std::vector<acl_kernel_if_addr_range> accel_csr;
   std::vector<acl_kernel_if_addr_range> accel_perf_mon;
   std::vector<unsigned int> accel_num_printfs;
@@ -73,9 +82,6 @@ typedef struct {
   // read/write functions in case those are accidentally invoked too early,
   // e.g., in a future code refactoring.
   bool cra_ring_root_exist = false;
-
-  // Depth of hardware kernel invocation queue
-  std::vector<unsigned int> accel_invoc_queue_depth;
 
   // Track which of the kernels is the autorun profiling kernel (-1 if none)
   int autorun_profiling_kernel_id;

--- a/include/acl_thread.h
+++ b/include/acl_thread.h
@@ -67,20 +67,13 @@ static inline void acl_sig_finished() {
 }
 
 // Blocking/Unblocking signals (Only implemented for Linux)
-#ifdef __linux__
-extern ACL_TLS sigset_t acl_sigset;
-static inline void acl_sig_block_signals() {
-  sigset_t mask;
-  if (sigfillset(&mask))
-    assert(0 && "Error in creating signal mask in status handler");
-  if (pthread_sigmask(SIG_BLOCK, &mask, &acl_sigset))
-    assert(0 && "Error in blocking signals in status handler");
-}
-static inline void acl_sig_unblock_signals() {
-  if (pthread_sigmask(SIG_SETMASK, &acl_sigset, NULL))
-    assert(0 && "Error in unblocking signals in status handler");
-}
-#endif
+class acl_signal_blocker {
+public:
+  acl_signal_blocker &operator=(const acl_signal_blocker &) = delete;
+  acl_signal_blocker(const acl_signal_blocker &) = delete;
+  acl_signal_blocker();
+  ~acl_signal_blocker();
+};
 
 // -- global lock functions --
 

--- a/src/acl_hal_mmd.cpp
+++ b/src/acl_hal_mmd.cpp
@@ -1985,13 +1985,13 @@ int acl_hal_mmd_program_device(unsigned int physical_device_id,
 
 void acl_hal_mmd_kernel_interrupt(int handle_in, void *user_data) {
   unsigned physical_device_id;
-#ifdef __linux__
+
   // Callbacks received from non-dma transfers.
   // (those calls are not initiated by a signal handler, so we need to block all
   // signals here to avoid simultaneous calls to signal handler.)
-  acl_sig_block_signals(); // Call before acl_sig_started. Must call
-                           // acl_sig_unblock_signals after acl_sig_finished.
-#endif
+  // Must instantiate before acl_sig_started, destruct after acl_sig_finished.
+  acl_signal_blocker sig_blocker;
+
   acl_sig_started();
   // NOTE: all exit points of this function must first call acl_sig_finished()
 
@@ -2005,10 +2005,6 @@ void acl_hal_mmd_kernel_interrupt(int handle_in, void *user_data) {
     assert(acl_kernel_if_is_valid(&kern[physical_device_id]));
     acl_kernel_if_update_status(&kern[physical_device_id]);
     acl_sig_finished();
-#ifdef __linux__
-    // Unblocking the signals we blocked
-    acl_sig_unblock_signals();
-#endif
     return;
   }
 
@@ -2021,14 +2017,13 @@ void acl_hal_mmd_device_interrupt(int handle_in,
                                   aocl_mmd_interrupt_info *data_in,
                                   void *user_data) {
   unsigned physical_device_id;
-#ifdef __linux__
+
   // Callbacks received from non-dma transfers.
-  //(those calls are not initiated by a signal handler, so we need to block all
-  // signals
-  // here to avoid simultaneous calls to signal handler.)
-  acl_sig_block_signals(); // Call before acl_sig_started. Must call
-                           // acl_sig_unblock_signals after acl_sig_finished.
-#endif
+  // (those calls are not initiated by a signal handler, so we need to block all
+  // signals here to avoid simultaneous calls to signal handler.)
+  // Must instantiate before acl_sig_started, destruct after acl_sig_finished.
+  acl_signal_blocker sig_blocker;
+
   acl_sig_started();
   // NOTE: all exit points of this function must first call acl_sig_finished()
 
@@ -2042,10 +2037,6 @@ void acl_hal_mmd_device_interrupt(int handle_in,
     acl_device_update_fn(physical_device_id, data_in->exception_type,
                          data_in->user_private_info, data_in->user_cb);
     acl_sig_finished();
-#ifdef __linux__
-    // Unblocking the signals we blocked
-    acl_sig_unblock_signals();
-#endif
     return;
   }
 
@@ -2056,14 +2047,12 @@ void acl_hal_mmd_device_interrupt(int handle_in,
 
 void acl_hal_mmd_status_handler(int handle, void *user_data, aocl_mmd_op_t op,
                                 int status) {
-#ifdef __linux__
   // Callbacks received from non-dma transfers.
-  //(those calls are not initiated by a signal handler, so we need to block all
-  // signals)
-  // here to avoid simultaneous  calls to signal handler.)
-  acl_sig_block_signals(); // Call before acl_sig_started. Must call
-                           // acl_sig_unblock_signals after acl_sig_finished.
-#endif
+  // (those calls are not initiated by a signal handler, so we need to block all
+  // signals here to avoid simultaneous calls to signal handler.)
+  // Must instantiate before acl_sig_started, destruct after acl_sig_finished.
+  acl_signal_blocker sig_blocker;
+
   acl_sig_started();
   // NOTE: all exit points of this function must first call acl_sig_finished()
   // Removing Windows warning
@@ -2073,10 +2062,6 @@ void acl_hal_mmd_status_handler(int handle, void *user_data, aocl_mmd_op_t op,
   acl_event_update_fn((cl_event)op, CL_COMPLETE);
 
   acl_sig_finished();
-#ifdef __linux__
-  // Unblocking the signals we blocked
-  acl_sig_unblock_signals();
-#endif
 }
 
 void acl_hal_mmd_register_callbacks(

--- a/src/acl_thread.cpp
+++ b/src/acl_thread.cpp
@@ -135,6 +135,27 @@ static void l_init_once() {
 
 #endif // !LINUX
 
+// Blocking/Unblocking signals (Actual implementation only for Linux)
+acl_signal_blocker::acl_signal_blocker() {
+#ifdef __linux__
+  sigset_t mask;
+  if (sigfillset(&mask)) {
+    assert(0 && "Error in creating signal mask in status handler");
+  }
+  if (pthread_sigmask(SIG_BLOCK, &mask, &acl_sigset)) {
+    assert(0 && "Error in blocking signals in status handler");
+  }
+#endif
+}
+
+acl_signal_blocker::~acl_signal_blocker() {
+#ifdef __linux__
+  if (pthread_sigmask(SIG_SETMASK, &acl_sigset, NULL)) {
+    assert(0 && "Error in unblocking signals in status handler");
+  }
+#endif
+}
+
 // Current thread releases mutex lock and sleeps briefly to allow other threads
 // a chance to execute. This function is useful for multithreaded hosts with
 // e.g. polling BSPs (using yield) to prevent one thread from hogging the mutex


### PR DESCRIPTION
When multiple threads may access the kernel CRA registers and there are enough kernel that segment register may be modified throughout the run, we need to ensure there is no more additional segment updates coming in between a segment update and consequent CRA read/write.