### PR TITLE
Run runtime fuzz tests on GitHub hosted runner

### DIFF
--- a/.github/workflows/fuzz-test.yml
+++ b/.github/workflows/fuzz-test.yml
@@ -16,21 +16,13 @@ on:
 
 jobs:
   build:
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - container
+    runs-on: ubuntu-22.04
 
     container:
       image: ghcr.io/intel/fpga-runtime-for-opencl/ubuntu-22.04-dev:main
 
     name: Fuzz Testing
     steps:
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.10'
     - name: Clone Radamsa
       run: |
         mkdir radamsa_repo

--- a/container/opensuse-leap-15-dev/Dockerfile
+++ b/container/opensuse-leap-15-dev/Dockerfile
@@ -45,4 +45,7 @@ USER build
 WORKDIR /home/build
 
 ENV PATH="/opt/aocl/hld/bin:$PATH"
+# Workaround for libnsl.so.1 not installed by default on the latest OpenSUSE image
+RUN mkdir -p /tmp/aoc && ln -snf /usr/lib64/libnsl.so.2.0.0 /tmp/aoc/libnsl.so.1
+ENV LD_LIBRARY_PATH="/tmp/aoc:$LD_LIBRARY_PATH"
 RUN aoc -version

--- a/container/ubuntu-22.04-dev/Dockerfile
+++ b/container/ubuntu-22.04-dev/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get -y update \
   libxml2 \
   ninja-build \
   python3 \
+  python3-pip \
   sudo \
   zlib1g-dev \
   && apt-get -y clean \

--- a/fuzz_testing/script/fuzz_test.py
+++ b/fuzz_testing/script/fuzz_test.py
@@ -84,7 +84,7 @@ def fuzz_test_main(test_file_name, group, test, var, original_value, all_outputs
     # Mutate variable
     fuzz_var_str = "Fuzzing variable: " + group + "--" + test + "--" + var
     print("      " + fuzz_var_str)
-    mutation_command = ["python", "mutator.py", test_file_name, group, test, var]
+    mutation_command = ["python3", "mutator.py", test_file_name, group, test, var]
     # mutated_value = subprocess.check_output(mutation_command) 
     original_value_message = "Original value: \n" + original_value
     subprocess.check_output(mutation_command) 


### PR DESCRIPTION
Runtime fuzz tests introduced in #298 currently runs on the runtime self-hosted machine, this change modifies the workflow to run on GitHub hosted runner so that we maintain a minimum set that have to be run on the self-hosted machine.

Reference: [comment](https://github.com/intel/fpga-runtime-for-opencl/pull/298#discussion_r1267189157)