### PR TITLE
Handle printf format as the last item in the format string

### DIFF
--- a/src/acl_printf.cpp
+++ b/src/acl_printf.cpp
@@ -893,7 +893,7 @@ static size_t l_dump_printf_buffer(cl_event event, cl_kernel kernel,
 #endif
 
       // no data to be printed, end of printing for this printf
-      if (ptr == format_string.cend())
+      if (ptr == format_string.cend() && data_elem._conversion_string.empty())
         break;
 
       // Handle vector types by replicating the conversion string for each


### PR DESCRIPTION
The code in l_dump_printf_buffer incorrectly assumes that each printf %format in a format string is followed by at least one character.  In the case of **printf("%d", 10);**, this is not the case, and the code will not print the value.

The fix is to exit only when the format string has been processed and there is no conversion to be done.
Note that most printf formats end with an **\n**, so this problem doesn't occur.