### PR TITLE
Security: Remove hardcoded paths being built into libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,18 @@ if(ACL_TSAN)
   endforeach()
 endif()
 
+function(define_file_basename_for_sources targetname)
+    get_target_property(source_files "${targetname}" SOURCES)
+    foreach(sourcefile ${source_files})
+        # Add the FILE_BASENAME=filename compile definition to the list.
+        get_filename_component(basename "${sourcefile}" NAME)
+        # Set the updated compile definitions on the source file.
+        set_property(
+            SOURCE "${sourcefile}" APPEND
+            PROPERTY COMPILE_DEFINITIONS "__FILE__=\"${basename}\"")
+    endforeach()
+endfunction()
+
 include(CPack)
 include(CTest)
 

--- a/lib/acl_hash/CMakeLists.txt
+++ b/lib/acl_hash/CMakeLists.txt
@@ -8,6 +8,9 @@ set_property(TARGET acl_hash PROPERTY PUBLIC_HEADER
   include/acl_hash/acl_hash.h
   )
 
+
+define_file_basename_for_sources(acl_hash)
+
 install(TARGETS acl_hash
   COMPONENT acl_hash
   EXCLUDE_FROM_ALL

--- a/lib/acl_threadsupport/CMakeLists.txt
+++ b/lib/acl_threadsupport/CMakeLists.txt
@@ -8,6 +8,8 @@ set_property(TARGET acl_threadsupport PROPERTY PUBLIC_HEADER
   include/acl_threadsupport/acl_threadsupport.h
   )
 
+define_file_basename_for_sources(acl_threadsupport)
+
 install(TARGETS acl_threadsupport
   COMPONENT acl_threadsupport
   EXCLUDE_FROM_ALL

--- a/lib/pkg_editor/CMakeLists.txt
+++ b/lib/pkg_editor/CMakeLists.txt
@@ -22,6 +22,8 @@ if(ZLIB_FOUND)
   target_link_libraries(pkg_editor PRIVATE ZLIB::ZLIB)
 endif()
 
+define_file_basename_for_sources(pkg_editor)
+
 install(TARGETS pkg_editor
   COMPONENT pkg_editor
   EXCLUDE_FROM_ALL


### PR DESCRIPTION
This change removes the full path when building some libs, to make sure the resulting library has fewer full paths to where the build occurred. (Note that this change does not completely remove all build-time hardcoded paths, that is still a work in progress, but it does remove some of them).

Tests run:
Tested some simulator runs as part of a test set. 