### PR TITLE
Refactor queue submission to resolve a hang

### DIFF
--- a/src/acl_device_op.cpp
+++ b/src/acl_device_op.cpp
@@ -1474,10 +1474,6 @@ void acl_post_status_to_owning_event(acl_device_op_t *op, int new_status) {
     command_queue->num_commands_submitted--;
   } else {
     event->timestamp[new_status] = op->timestamp[new_status];
-
-    if (command_queue->properties & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) {
-      acl_try_FastKernelRelaunch_ooo_queue_event_dependents(event);
-    }
   }
 }
 

--- a/src/acl_event.cpp
+++ b/src/acl_event.cpp
@@ -1078,16 +1078,6 @@ int acl_notify_dependent_events(cl_event event) {
     if (event->cmd.type == CL_COMMAND_USER && event->execution_status < 0) {
       acl_set_execution_status(dependent, event->execution_status);
     }
-
-    // Submit the event if it has no dependencies and is partt of an
-    // Out-of-order queue
-    if (dependent->command_queue->properties &
-            CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE &&
-        dependent->depend_on.empty() &&
-        dependent->cmd.type != CL_COMMAND_USER) {
-      dependent->command_queue->num_commands_submitted++;
-      acl_submit_command(dependent);
-    }
   }
 
   int num_updates = static_cast<int>(event->depend_on_me.size());


### PR DESCRIPTION
when fast kernel relaunching many dependent events in a row.  

This removes a circular dependence and recursion between acl_command_queue and acl_device_op and thus makes the code much simpler to reason about.  All commands are now submitted by the acl_update_*_queue functions.  