### PR TITLE
Update the runtime to remove old glibc exceptions that are no longer needed after the new compiler update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,12 +308,6 @@ set_target_properties(acl_objs PROPERTIES
 target_compile_features(acl_objs PRIVATE cxx_std_11)
 # These compile_definitions need to be public, since we're building an OBJECT library (?)
 target_compile_definitions(acl_objs PUBLIC
-  # Revert to old pre-C++11 ABI for std::string and std::list in libstdc++.
-  # This is needed for ABI compatibility with the Intel® FPGA Add-On for
-  # oneAPI Base Toolkit, particularly the simulation flow, which accesses
-  # the internal runtime API that exposes C++ structures and functions.
-  # https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html
-  _GLIBCXX_USE_CXX11_ABI=0
   ACL_SUPPORT_DOUBLE=1
   ACL_HAS_STDLIB_STDIO
   CL_USE_DEPRECATED_OPENCL_1_0_APIS=1

--- a/fuzz_testing/test/CMakeLists.txt
+++ b/fuzz_testing/test/CMakeLists.txt
@@ -14,7 +14,6 @@ add_executable(acl_fuzz_test
 set_target_properties(acl_fuzz_test PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_features(acl_fuzz_test PRIVATE cxx_std_11)
 target_compile_definitions(acl_fuzz_test PRIVATE
-  _GLIBCXX_USE_CXX11_ABI=0
   "ACL_TARGET_BIT=${ACL_TARGET_BIT}"
   CL_USE_DEPRECATED_OPENCL_1_0_APIS=1
   CL_USE_DEPRECATED_OPENCL_1_1_APIS=1

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,6 @@ add_executable(acl_test
 set_target_properties(acl_test PROPERTIES CXX_EXTENSIONS OFF)
 target_compile_features(acl_test PRIVATE cxx_std_11)
 target_compile_definitions(acl_test PRIVATE
-  _GLIBCXX_USE_CXX11_ABI=0
   "ACL_TARGET_BIT=${ACL_TARGET_BIT}"
   CL_USE_DEPRECATED_OPENCL_1_0_APIS=1
   CL_USE_DEPRECATED_OPENCL_1_1_APIS=1


### PR DESCRIPTION
Remove the calls to use the old glibc.